### PR TITLE
Deployer changes

### DIFF
--- a/resources/deployer/deployer.sh
+++ b/resources/deployer/deployer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 CD_HOME=${CRAFTER_DEPLOYER_HOME:=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}
 C_HOME=${C_HOME:="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../}
-DEPLOYER_JAVA_OPTS="$DEPLOYER_JAVA_OPTS -Ddeployer.main.homePath=$C_HOME/data/deployer"
+DEPLOYER_JAVA_OPTS="$DEPLOYER_JAVA_OPTS -Dlogging.config=logback-spring.xml -Ddeployer.main.deployments.output.folderPath=logs -Ddeployer.main.logging.folderPath=logs -Ddeployer.main.homePath=$C_HOME/data/deployer"
 PID=${DEPLOYER_PID:="crafter-deployer.pid"}
 OUTPUT=${CRAFTER_DEPLOYER_SDOUT:='crafter-deployer.log'}
 echo $C_HOME
@@ -39,7 +39,7 @@ function help() {
 }
 case $1 in
     -d|--debug)
-        set DEPLOYER_JAVA_OPTS = "$DEPLOYER_JAVA_OPTS  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+        set DEPLOYER_JAVA_OPTS = "$DEPLOYER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
         start
     ;;
     -s|--start)

--- a/resources/deployer/logback-spring.xml
+++ b/resources/deployer/logback-spring.xml
@@ -1,0 +1,33 @@
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+
+    <springProperty scope="context" name="LOGS_PATH" source="deployer.main.logging.folderPath" defaultValue="./logs"/>
+
+    <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+        <!-- in the absence of the class attribute, it is assumed that the
+             desired discriminator type is
+             ch.qos.logback.classic.sift.MDCBasedDiscriminator -->
+        <discriminator>
+            <key>targetId</key>
+            <defaultValue>deployer-general</defaultValue>
+        </discriminator>
+        <sift>
+            <appender name="FILE-${targetId}" class="ch.qos.logback.core.FileAppender">
+                <file>${LOGS_PATH}/${targetId}.log</file>
+                <layout class="ch.qos.logback.classic.PatternLayout">
+                    <pattern>${FILE_LOG_PATTERN}</pattern>
+                </layout>
+            </appender>
+        </sift>
+    </appender>
+
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.craftercms" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="SIFT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
* Added a logback-spring.xml so that changing logging can be more easy.
* All log output now will appear under the current deployment folder, instead of data, so as to keep consistency with other Crafter processes like Tomcat and Solr.