### PR TITLE
Gradle external process output is now redirected to a file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -406,11 +406,11 @@ def cloneModule(commandLinePrefix, module){
         return tasks.create("clone${module}") {
             def finalUrl = "${gitURLTemplate}${module}.git".toString()
             def path = "src/${module}".toString()
-
             def arry = commandLinePrefix + ["git","clone","-b",sourceBranch,finalUrl,path]
             if (file(path).exists()) {
                 throw new InvalidUserDataException("Module ${module} has already been initialized, please use 'init' to update it.")
             } else {
+                println "Cloning ${module} branch ${} from ${finalUrl}"
                 executeProcess(arry,".")
             }
         }
@@ -574,7 +574,6 @@ def pack(environmentPath,envName){
 def executeProcess(command, workingDir, printOutputUntilFinish = false) {
     ProcessBuilder pb = new ProcessBuilder(command)
     def processOutput = new File("./processOutput.out")
-    processOutput.deleteOnExit() //clean
     pb.directory(new File(workingDir))
     pb.redirectOutput(processOutput)
     Process proc = pb.start();
@@ -585,11 +584,15 @@ def executeProcess(command, workingDir, printOutputUntilFinish = false) {
 // Poor's man tail (but get's the job done
 def watchProcessOutput(process, processOutputFile){
     Thread.start {
+        // Just "wait" until file exists.
+        while(!processOutputFile.exists()){
+        }
+
         def reader=Files.newBufferedReader(Paths.get(processOutputFile.path))
         while(process.alive){
            // Thread.sleep(100)
-            def line=reader.readLine();
-            if(line) {
+            def line=null
+            while((line=reader.readLine())!=null){
                 println line
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardWatchEventKinds
+
 plugins {
     id "de.undercouch.download" version "3.1.2"
 }
@@ -569,11 +573,26 @@ def pack(environmentPath,envName){
 
 def executeProcess(command, workingDir, printOutputUntilFinish = false) {
     ProcessBuilder pb = new ProcessBuilder(command)
+    def processOutput = new File("./processOutput.out")
+    processOutput.deleteOnExit() //clean
     pb.directory(new File(workingDir))
-    pb.redirectErrorStream(true)
-   // pb.inheritIO()
+    pb.redirectOutput(processOutput)
     Process proc = pb.start();
-    proc.inputStream.eachLine {println it}
-    proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
+    watchProcessOutput(proc,processOutput)
+    proc.waitFor()
+}
 
+// Poor's man tail (but get's the job done
+def watchProcessOutput(process, processOutputFile){
+    Thread.start {
+        def reader=Files.newBufferedReader(Paths.get(processOutputFile.path))
+        while(process.alive){
+           // Thread.sleep(100)
+            def line=reader.readLine();
+            if(line) {
+                println line
+            }
+        }
+        processOutputFile.delete()
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -408,9 +408,10 @@ def cloneModule(commandLinePrefix, module){
             def path = "src/${module}".toString()
             def arry = commandLinePrefix + ["git","clone","-b",sourceBranch,finalUrl,path]
             if (file(path).exists()) {
-                throw new InvalidUserDataException("Module ${module} has already been initialized, please use 'init' to update it.")
+                println ("Module ${module} has already been initialized, please use " +
+                        "'update' to update it.")
             } else {
-                println "Cloning ${module} branch ${sourceBranch} from ${finalUrl}"
+                println "Cloning:${module}, branch:${sourceBranch}, url: ${finalUrl}"
                 executeProcess(arry,".")
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -411,7 +411,7 @@ def cloneModule(commandLinePrefix, module){
                 println ("Module ${module} has already been initialized, please use " +
                         "'update' to update it.")
             } else {
-                println "Cloning:${module}, branch:${sourceBranch}, url: ${finalUrl}"
+                println "Cloning: ${module}, branch: ${sourceBranch}, url: ${finalUrl}"
                 executeProcess(arry,".")
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -410,7 +410,7 @@ def cloneModule(commandLinePrefix, module){
             if (file(path).exists()) {
                 throw new InvalidUserDataException("Module ${module} has already been initialized, please use 'init' to update it.")
             } else {
-                println "Cloning ${module} branch ${} from ${finalUrl}"
+                println "Cloning ${module} branch ${sourceBranch} from ${finalUrl}"
                 executeProcess(arry,".")
             }
         }

--- a/environments.gradle
+++ b/environments.gradle
@@ -274,7 +274,7 @@ task("deliveyEnviroment"){
         }
         updateTomcatPorts("${liveEnv}/bin/apache-tomcat/conf/server.xml",liveTomcatPort,liveTomcatAJPPort,
                 liveTomcatShutdownPort,liveTomcatSSLPort)
-
+        updateCatalinaSettings(liveEnv)
         updateTomcatContext("${liveEnv}/bin/apache-tomcat/conf/context.xml")
         updateCatalinaLogging("${liveEnv}/bin/apache-tomcat/conf/logging.properties")
         addSolrIndexHome("${liveEnv}/bin/solr/server/solr/solr.xml")


### PR DESCRIPTION
Gradle external process output is now redirected to a file which is "tailed" by a different thread that the one running the gradle.

`\r`does not play well with Process redirect outputstream but when saved on file (that get's converted in a `\n` by Java's internals ) it does work just fine.

Init process also won't stop if something is already cloned It will just log and carry on. 