### PR TITLE
Fix blinking blue message after startup

### DIFF
--- a/resources/crafter/crafter.sh
+++ b/resources/crafter/crafter.sh
@@ -56,7 +56,7 @@ function checkPortForRunning(){
 }
 
 function printTailInfo(){
-  echo -e "\033[34;5;196m"
+  echo -e "\033[38;5;196m"
   echo "Log files live here: \"$CRAFTER_ROOT/logs/\". "
   echo "To follow the main tomcat log, you can \"tail -f $CRAFTER_ROOT/logs/tomcat/catalina.out\""
   echo -e "\033[0m"


### PR DESCRIPTION
This may be a typo. The message about where to find logs is blinking blue, making it hard to see and cut/paste. Changing it to non-blinking red like other part of the script.