### PR TITLE
Multiple Windows Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,7 @@ task("build") {
     }
 }
 
-task("test") {
+task test(dependsOn: ["build", "deploy"]) {
     description "Builds and run tests"
     doFirst {
         def driverPath=""

--- a/build.gradle
+++ b/build.gradle
@@ -379,13 +379,11 @@ task("test") {
     doLast{
        startAuth(commandLinePrefix, startUpFile)
        try {
-            if (waitUntilAuthIsUp(10)){ // 10 times of 15 sec each upto 2.5 min
+
                 buildModule(commandLinePrefix,
                         "test-suite", "./src/",
                         ["-Dfile=src/test/resources/testng.xml,src/test/resources/testngcomplexscenarios.xml,src/test/resources/testngAPI.xml"])
-            }else{
-                println "After ${(10*15)/60} min we where unable to check if studio is up"
-            }
+
         }catch (GradleException ex){ // no nothing
         } finally {
             stopAuth(commandLinePrefix, shutDownFile)

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,24 @@ import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardWatchEventKinds
+import java.io.BufferedReader;
+import java.nio.file.StandardOpenOption;
+import java.net.HttpURLConnection;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.lang3.SystemUtils;
+
+
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath group: 'org.apache.commons', name: 'commons-text', version: '1.1'
+        classpath group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
+
+    }
+}
 
 plugins {
     id "de.undercouch.download" version "3.1.2"
@@ -102,9 +120,10 @@ ext {
     forceDeploy=project.hasProperty("forceDeploy")? project.property("forceDeploy") : false
     keepBin=project.hasProperty("keepBin")? project.property("keepBin") : false
 
-    testingPlatform=project.hasProperty("crafter.testing.platform")? project.property("crafter.testing.plataform") : System.properties['os.name'].toString().toLowerCase()
+    testingPlatform=project.hasProperty("crafter.testing.platform")? project.property("crafter.testing.plataform") : System.properties['os.name'].toString().toLowerCase().replaceAll(" ","-")
     chromeDriverVersion=project.hasProperty("crafter.testing.chrome")? project.property("crafter.testing.chrome") : 2.31
     browserToTest=project.hasProperty("crafter.testing.browser")? project.property("crafter.testing.browser") : "chrome"
+    testArtifacts=project.hasProperty("crafter.unittest") ? project.property("crafter.unittest") : false
 
     /** Clonable Artifacts **/
     VALID_MODULES=["commons", "core", "search", "profile", "engine", "deployer", "studio", "social", "studio-ui", "test-suite"]
@@ -116,6 +135,12 @@ ext {
             "deployer":"./src/deployer/target/crafter-deployer.jar",
             "studio":"./src/studio/target/studio.war",
             "social":"./src/social/server/target/crafter-social.war"]
+    WINDOWS_EDGE_DRIVER_URL = [
+        "15063" : "https://download.microsoft.com/download/3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/MicrosoftWebDriver.exe",
+        "14393" : "https://download.microsoft.com/download/3/2/D/32D3E464-F2EF-490F-841B-05D53C848D15/MicrosoftWebDriver.exe",
+        "10586" :  "https://download.microsoft.com/download/C/0/7/C07EBF21-5305-4EC8-83B1-A6FCC8F93F45/MicrosoftWebDriver.msi",
+        "10240" : "https://download.microsoft.com/download/8/D/0/8D0D08CF-790D-4586-B726-C6469A9ED49C/MicrosoftWebDriver.msi"
+    ]
 
 }
 
@@ -323,12 +348,17 @@ task("build") {
 
 task("test") {
     description "Builds and run tests"
+    testArtifacts= true
     doFirst {
         def driverPath=""
         switch (browserToTest.toString().toLowerCase()){
             case "chrome":
                 downloadChromeDriver.execute()
-                driverPath=file("./src/test-suite/bin/${browserToTest}-${testingPlatform}/chromedriver")
+                if(SystemUtils.IS_OS_WINDOWS){
+                    driverPath=file("./src/test-suite/bin/${browserToTest}-${testingPlatform}/chromedriver.exe")
+                }else{
+                    driverPath=file("./src/test-suite/bin/${browserToTest}-${testingPlatform}/chromedriver")
+                }
                 break;
             case "edge":
                 downloadEdgeDriver.execute();
@@ -338,23 +368,28 @@ task("test") {
                 driverPath=askForPath();
         }
         if(!file("./src/test-suite/test-properties.properties").exists()){
-            Properties properties = new Properties();
-            properties.setProperty("webBrowser", browserToTest)
-            properties.setProperty("baseUrl", "http://localhost:8080/studio/#/login")
-            properties.setProperty("${browserToTest}.driver.path", file(driverPath).absoluteFile.absolutePath)
-            properties.store(new FileOutputStream("./src/test-suite/test-properties.properties"),
-                    "Saved by gradle")
+            def properties = []
+            properties.add("webBrowser=${browserToTest}")
+            properties.add("baseUrl=http://localhost:8080/studio/#/login")
+            properties.add("${browserToTest}.driver.path=${StringEscapeUtils.escapeJava(file(driverPath).absolutePath)}")
+            Files.write(Paths.get("./src/test-suite/test-properties.properties"), properties, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
         }
     }
+    
     doLast{
-
-        startAuth(commandLinePrefix, startUpFile)
-        try {
-            buildModule(commandLinePrefix,
-                    "test-suite", "./src/", ["-Dfile=src/test/resources/testngcomplexscenarios.xml,src/test/resources/testng.xml,src/test/resources/testngAPI.xml"])
+       startAuth(commandLinePrefix, startUpFile)
+       try {
+            if (waitUntilAuthIsUp(10)){ // 10 times of 15 sec each upto 2.5 min
+                buildModule(commandLinePrefix,
+                        "test-suite", "./src/",
+                        ["-Dfile=src/test/resources/testng.xml,src/test/resources/testngcomplexscenarios.xml,src/test/resources/testngAPI.xml"])
+            }else{
+                println "After ${(10*15)/60} min we where unable to check if studio is up"
+            }
+        }catch (GradleException ex){ // no nothing
         } finally {
             stopAuth(commandLinePrefix, shutDownFile)
-        }
+        }        
     }
 }
 
@@ -431,6 +466,7 @@ task("bundle") {
         }
     }
 }
+
 
 def cleanModule(commandLinePrefix, module) {
     def ctask=tasks.findByPath("clean${module}")
@@ -531,7 +567,7 @@ def buildModule(commandLinePrefix, module, path="./src/", commandLinePost=[]) {
         return btask
     } else {
         return tasks.create("build${module}") {
-            if (!project.hasProperty("crafter.unittest")) {
+            if (!testArtifacts) {
                 actualCommandLinePost.add("-Dmaven.test.skip=true")
             }
             if(module.equalsIgnoreCase("studio") && !studioUIFromRepo) {
@@ -688,4 +724,24 @@ def askForPath(){
         askForPath();
     }
     return inputPath
+}
+
+def waitUntilAuthIsUp(tryThinsManyTimes){
+    if(tryThinsManyTimes<=0){
+        return false
+    }else{
+        try{
+            URL url = new URL("http://localhost:${authTomcatPort}/studio");
+            HttpURLConnection huc = (HttpURLConnection) url.openConnection();
+            HttpURLConnection.setFollowRedirects(false);
+            huc.setConnectTimeout(15 * 1000);
+            huc.setRequestMethod("GET");
+            huc.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729)");
+            huc.connect();
+            return true
+        }catch(java.net.SocketTimeoutException | java.net.ConnectException ex){
+            println "Studio is not Ready yet trying again"
+            waitUntilAuthIsUp(tryThinsManyTimes-1)
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ task("upgrade"){
                 }
             }
         }
-
+        update.execute();
         forceDeploy=true
         build.execute()
         deploy.execute()

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardWatchEventKinds
@@ -320,7 +321,7 @@ task("build") {
     }
 }
 
-task test(dependsOn: ["build", "deploy"]) {
+task("test") {
     description "Builds and run tests"
     doFirst {
         def driverPath=""
@@ -350,7 +351,8 @@ task test(dependsOn: ["build", "deploy"]) {
         startAuth(commandLinePrefix, startUpFile)
         try {
             buildModule(commandLinePrefix,
-                    "test-suite", "./src/", ["-Dfile=src/test/resources/testngcomplexscenarios.xml"])
+                    "test-suite", "./src/",
+                    ["-Dfile=src/test/resources/testng.xml,src/test/resources/testngcomplexscenarios.xml,src/test/resources/testngAPI.xml"])
         } finally {
             stopAuth(commandLinePrefix, shutDownFile)
         }
@@ -524,19 +526,21 @@ def stopDelivery(commandLinePrefix, shutDownFile) {
 
 def buildModule(commandLinePrefix, module, path="./src/", commandLinePost=[]) {
     def btask=tasks.findByPath("build${module}")
+    def actualCommandLinePost = [];
+    actualCommandLinePost.addAll(commandLinePost)
     if (btask!= null) {
         return btask
     } else {
         return tasks.create("build${module}") {
-            if (!project.hasProperty("test")) {
-                commandLinePost.add("-Dmaven.test.skip=true")
+            if (!project.hasProperty("crafter.unittest")) {
+                actualCommandLinePost.add("-Dmaven.test.skip=true")
             }
             if(module.equalsIgnoreCase("studio") && !studioUIFromRepo) {
-                commandLinePost.add("-Dstudio.ui.path=../studio-ui/".toString())
-                commandLinePost.add("-Dexec.skip=true")
+                actualCommandLinePost.add("-Dstudio.ui.path=../studio-ui/".toString())
+                actualCommandLinePost.add("-Dexec.skip=true")
             }
             // Always do a Clean build, never trust caches or FS.
-            def array=commandLinePrefix +  commandLinePrefix + ["mvn", "clean", "install"] + commandLinePost
+            def array=commandLinePrefix +  commandLinePrefix + ["mvn", "clean", "install"] + actualCommandLinePost
             executeProcess(array, "${path}${module}".toString())
         }
     }
@@ -659,7 +663,13 @@ def executeProcess(command, workingDir, printOutputUntilFinish = false) {
 // Poor's man tail (but get's the job done
 def watchProcessOutput(process, processOutputFile){
     Thread.start {
-        def reader=Files.newBufferedReader(Paths.get(processOutputFile.path))
+
+        def reader=null
+        if(System.getProperty('os.name').toLowerCase().contains('windows')){
+            reader = Files.newBufferedReader(Paths.get(processOutputFile.path), Charset.forName("ISO-8859-1"))
+        }else{
+            reader = Files.newBufferedReader(Paths.get(processOutputFile.path), Charset.forName("UTF-8"))
+        }
         while(process.alive) {
             // Thread.sleep(100)
             def line=null

--- a/downloads.gradle
+++ b/downloads.gradle
@@ -1,5 +1,17 @@
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath group: 'org.apache.commons', name: 'commons-text', version: '1.1'
+        classpath group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
+
+    }
+}
+
 import java.security.MessageDigest;
+import org.apache.commons.lang3.SystemUtils;
 
 task downloadTomcat() {
     description = "Downloads and checks tomcat integrity"
@@ -43,11 +55,27 @@ task downloadSolr() {
 
 task downloadEdgeDriver(){
     doFirst{
-        file("./src/craftercms-test-suite/bin/edge/").mkdir()
-        download{
-            src "https://download.microsoft.com/download/3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/MicrosoftWebDriver.exe"
-            overwrite false
-            dest ("./src/craftercms-test-suite/bin/edge/MicrosoftWebDriver.exe")
+        file("./src/test-suite/bin/").mkdir()
+       def winBuildNumber =getWindowsBuildNumber();
+        def url=""
+        if(WINDOWS_EDGE_DRIVER_URL.containsKey(winBuildNumber)){
+            url=WINDOWS_EDGE_DRIVER_URL[winBuildNumber]
+        }
+        if(url.endsWith(".msi")){
+            println ("Your current Selenium Driver is an MSI installer, please \n install it in this path `./src/test-suite/bin` and make sure that you configure properly the `./src/test-suite/test-properties.properties`")
+        }
+        if(!url.isEmpty()){
+            println url
+            download{
+                src url
+                overwrite false
+                dest ("./src/test-suite/bin/edge/MicrosoftWebDriver.exe")
+                acceptAnyCertificate true
+            }
+        }else{
+            println "We could not found a suitable selenium driver for your windows build  ${winBuildNumber}"
+            println "Please go to https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/ and download"
+            println "the proper driver version and then configure its location in the `./src/test-suite/test-properties.properties` file " 
         }
     }
 }
@@ -55,28 +83,25 @@ task downloadEdgeDriver(){
 task downloadChromeDriver(){
     doFirst{
         def plataform=""
-        switch (testingPlataform){
-            case "windows":
-                plataform="win32"
-                break;
-            case "linux":
-                plataform="linux64"
-                break;
-            default:
-                plataform="mac64"
-
+        if(SystemUtils.IS_OS_WINDOWS){
+            plataform = "win32"
+        }else if(SystemUtils.IS_OS_LINUX){
+            plataform = "linux64"
+        }else{
+            plataform = "mac64"
         }
         download{
             src "https://chromedriver.storage.googleapis.com/${chromeDriverVersion}/chromedriver_${plataform}.zip"
             overwrite false
-            dest ("./src/craftercms-test-suite/bin/chromedriver-${testingPlataform}.zip")
+            dest ("./src/test-suite/bin/chromedriver-${testingPlatform}.zip")
         }
         copy {
-            from zipTree("./src/craftercms-test-suite/bin/chromedriver-${testingPlataform}.zip")
-            into "./src/craftercms-test-suite/bin/${browserToTest}-${testingPlataform}/"
+            from zipTree("./src/test-suite/bin/chromedriver-${testingPlatform}.zip")
+            into "./src/test-suite/bin/${browserToTest}-${testingPlatform}/"
         }
     }
 }
+
 
 def sha1(file){
     MessageDigest md = MessageDigest.getInstance("SHA1");
@@ -93,4 +118,18 @@ def sha1(file){
         sb.append(Integer.toString((mdbytes[i] & 0xff) + 0x100, 16).substring(1));
     }
     return sb.toString()
+}
+
+def getWindowsBuildNumber(){
+     try {
+            def term = "OS Version"
+            Runtime rt = Runtime.getRuntime();
+            Process pr = rt.exec("CMD /C SYSTEMINFO | FINDSTR /B /C:\"" + term + "\"");
+            BufferedReader input = new BufferedReader(new InputStreamReader(pr.getInputStream()));
+             def fullwinVersion = input.readLine()
+             return fullwinVersion.substring(fullwinVersion.lastIndexOf("Build")+6)
+        } catch (IOException e) {
+            System.err.println(e.getMessage());
+        }
+        return "";
 }

--- a/downloads.gradle
+++ b/downloads.gradle
@@ -72,8 +72,8 @@ task downloadChromeDriver(){
             dest ("./src/craftercms-test-suite/bin/chromedriver-${testingPlataform}.zip")
         }
         copy {
-            from zipTree("./src/craftercms-test-suite/bin/chromedriver-${plataform}.zip")
-            into "./src/craftercms-test-suite/bin/chrome-${testingPlataform}/"
+            from zipTree("./src/craftercms-test-suite/bin/chromedriver-${testingPlataform}.zip")
+            into "./src/craftercms-test-suite/bin/${browserToTest}-${testingPlataform}/"
         }
     }
 }

--- a/resources/crafter/crafter.bat
+++ b/resources/crafter/crafter.bat
@@ -67,7 +67,8 @@ exit /b 0
  mkdir %CRAFTER_BIN_FOLDER%mongodb
  cd %CRAFTER_BIN_FOLDER%mongodb
  java -jar %CRAFTER_BIN_FOLDER%craftercms-utils.jar download mongodb
- msiexec.exe /i mongodb.msi /passive INSTALLLOCATION="%CRAFTER_BIN_FOLDER%mongodb\" /l*v "%CRAFTER_BIN_FOLDER%mongodb\mongodb.log" /norestart
+ java -jar  %CRAFTER_BIN_FOLDER%craftercms-utils.jar unzip mongodb.zip %CRAFTER_BIN_FOLDER%mongodb\bin true
+ rem msiexec.exe /i mongodb.msi /passive INSTALLLOCATION="%CRAFTER_BIN_FOLDER%mongodb\" /l*v "%CRAFTER_BIN_FOLDER%mongodb\mongodb.log" /norestart
  cd %CRAFTER_BIN_FOLDER%
 goto :init
 

--- a/resources/crafter/crafter.bat
+++ b/resources/crafter/crafter.bat
@@ -66,9 +66,14 @@ exit /b 0
 :installMongo
  mkdir %CRAFTER_BIN_FOLDER%mongodb
  cd %CRAFTER_BIN_FOLDER%mongodb
- java -jar %CRAFTER_BIN_FOLDER%craftercms-utils.jar download mongodb
- java -jar  %CRAFTER_BIN_FOLDER%craftercms-utils.jar unzip mongodb.zip %CRAFTER_BIN_FOLDER%mongodb\bin true
- rem msiexec.exe /i mongodb.msi /passive INSTALLLOCATION="%CRAFTER_BIN_FOLDER%mongodb\" /l*v "%CRAFTER_BIN_FOLDER%mongodb\mongodb.log" /norestart
+ java -jar %CRAFTER_BIN_FOLDER%craftercms-utils.jar download mongodbmsi
+ msiexec.exe /i mongodb.msi /passive INSTALLLOCATION="%CRAFTER_BIN_FOLDER%mongodb\" /l*v "%CRAFTER_BIN_FOLDER%mongodb\mongodb.log" /norestart
+ SET MONGODB_BIN_DIR= "%CRAFTER_BIN_FOLDER%mongodb\bin\mongod.exe"
+ IF NOT EXIST %MONGODB_BIN_DIR% (
+     echo "Mongodb bin path not found trying download the zip %MONGODB_BIN_DIR%"
+     java -jar %CRAFTER_BIN_FOLDER%craftercms-utils.jar download mongodb
+     java -jar  %CRAFTER_BIN_FOLDER%craftercms-utils.jar unzip mongodb.zip %CRAFTER_BIN_FOLDER%mongodb\bin true
+ )
  cd %CRAFTER_BIN_FOLDER%
 goto :init
 

--- a/resources/crafter/debug.sh
+++ b/resources/crafter/debug.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-CRAFTER_DEBUG_HOME=${CRAFTER_DEBUG_HOME:=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}
+CRAFTER_START_HOME=${CRAFTER_START_HOME:=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}
 
-if [[ -s  "$CRAFTER_DEBUG_HOME/crafter.sh" ]]; then
-      $CRAFTER_DEBUG_HOME/crafter.sh stop
+if [[ -s  "$CRAFTER_START_HOME/crafter.sh" ]]; then
+      $CRAFTER_START_HOME/crafter.sh debug
+      echo "Happy Crafting"
       exit 0
 else
       echo -e "\033[38;5;196m"
-      echo "crafter.sh was not found in $CRAFTER_DEBUG_HOME"
+      echo "crafter.sh was not found in $CRAFTER_START_HOME"
       echo -e "\033[0m"
       exit -1
 fi

--- a/utils/src/main/java/org/craftercms/bundle/utils/actions/Download.java
+++ b/utils/src/main/java/org/craftercms/bundle/utils/actions/Download.java
@@ -1,6 +1,11 @@
 package org.craftercms.bundle.utils.actions;
 
-import java.io.PrintStream;
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.craftercms.bundle.utils.Action;
 
@@ -8,6 +13,7 @@ import org.craftercms.bundle.utils.Action;
  * Created by cortiz on 4/27/17.
  */
 public class Download implements Action{
+    private static final int BUFFER_SIZE = 1024;
     /**
      * Output.
      */
@@ -18,10 +24,45 @@ public class Download implements Action{
         if (args.length <=0 ) {
             help();
         } else{
-            if (args[0].equalsIgnoreCase("mongodb")){
-                new DownloadMongoDB().execute(args);
+            switch (args[0].toLowerCase()){
+                case "mongodb":
+                    new DownloadMongoDB().execute(args);
+                    break;
+                case "mongodbmsi":
+                    new DownloadMongoMSIDB().execute(args);
+                    break;
+                default:
+                    URL downloadUrl = null;
+                    try {
+                        downloadUrl = new URL((args[0]));
+                        downloadUrl(downloadUrl, Paths.get(".", downloadUrl.getFile()));
+                    } catch (MalformedURLException e) {
+                        System.out.println(args[0]+ " is not a valid url");
+                    }
             }
         }
+    }
+
+
+    protected void downloadUrl(final URL downloadUrl, final Path saveTo){
+            try {
+                URLConnection connection = downloadUrl.openConnection();
+                InputStream input = connection.getInputStream();
+                OutputStream out = new FileOutputStream(saveTo.toFile());
+                byte[] buffer = new byte[BUFFER_SIZE];
+                int n;
+                long total = 0;
+                System.out.println("Downloading "+downloadUrl.toString()+" please wait.");
+                while ((n = input.read(buffer)) != -1) {
+                    out.write(buffer, 0, n);
+                    total += n;
+                }
+                out.flush();
+                out.close();
+                input.close();
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
     }
     @Override
     public void help() {

--- a/utils/src/main/java/org/craftercms/bundle/utils/actions/DownloadMongoDB.java
+++ b/utils/src/main/java/org/craftercms/bundle/utils/actions/DownloadMongoDB.java
@@ -22,7 +22,7 @@ public class DownloadMongoDB implements Action {
         switch (os) {
             case Windows:
                 builder = builder.replaceAll("@OS", "win32").replaceAll("@VERSION",
-                    "2008plus-ssl-v3.4-latest-signed").replaceAll("@EXT", "msi");
+                    "2008plus-ssl-v3.4-latest").replaceAll("@EXT", "zip");
                 break;
             case MacOS:
                 builder = builder.replaceAll("@OS", "osx").replaceAll("@VERSION", "3.4.4").replaceAll("@EXT", "tgz");
@@ -43,7 +43,7 @@ public class DownloadMongoDB implements Action {
                 InputStream input = connection.getInputStream();
                 File output = null;
                 if (OsCheck.getOperatingSystemType() == OsCheck.OSType.Windows) {
-                    output = Paths.get(".", "mongodb.msi").toFile();
+                    output = Paths.get(".", "mongodb.zip").toFile();
                 } else {
                     output = Paths.get(".", "mongodb.tgz").toFile();
                 }
@@ -51,7 +51,7 @@ public class DownloadMongoDB implements Action {
                 byte[] buffer = new byte[BUFFER_SIZE];
                 int n;
                 long total = 0;
-                System.out.println("Downloading Mongodb please wait.");
+                System.out.println("Downloading Mongodb "+builder.toString()+"please wait.");
                 while ((n = input.read(buffer)) != -1) {
                     out.write(buffer, 0, n);
                     total += n;

--- a/utils/src/main/java/org/craftercms/bundle/utils/actions/DownloadMongoDB.java
+++ b/utils/src/main/java/org/craftercms/bundle/utils/actions/DownloadMongoDB.java
@@ -51,7 +51,7 @@ public class DownloadMongoDB implements Action {
                 byte[] buffer = new byte[BUFFER_SIZE];
                 int n;
                 long total = 0;
-                System.out.println("Downloading Mongodb "+builder.toString()+"please wait.");
+                System.out.println("Downloading Mongodb "+builder.toString()+" please wait.");
                 while ((n = input.read(buffer)) != -1) {
                     out.write(buffer, 0, n);
                     total += n;

--- a/utils/src/main/java/org/craftercms/bundle/utils/actions/DownloadMongoMSIDB.java
+++ b/utils/src/main/java/org/craftercms/bundle/utils/actions/DownloadMongoMSIDB.java
@@ -1,0 +1,58 @@
+package org.craftercms.bundle.utils.actions;
+
+
+import org.craftercms.bundle.utils.Action;
+import org.craftercms.bundle.utils.OsCheck;
+
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Paths;
+
+/**
+ * Created by cortiz on 4/27/17.
+ */
+public class DownloadMongoMSIDB implements Action {
+
+    public static final int BUFFER_SIZE = 1024;
+
+    @Override
+    public void execute(String[] args) {
+        OsCheck.OSType os = OsCheck.getOperatingSystemType();
+        String builder = "http://downloads.mongodb.org/@OS/mongodb-@OS-x86_64-@VERSION.@EXT";
+        builder = builder.replaceAll("@OS", "win32").replaceAll("@VERSION",
+                    "2008plus-ssl-v3.4-latest-signed").replaceAll("@EXT", "msi");
+
+        try {
+            URL downloadUrl = new URL((builder));
+            try {
+                URLConnection connection = downloadUrl.openConnection();
+                InputStream input = connection.getInputStream();
+                File output = null;
+                output = Paths.get(".", "mongodb.msi").toFile();
+                OutputStream out = new FileOutputStream(output);
+                byte[] buffer = new byte[BUFFER_SIZE];
+                int n;
+                long total = 0;
+                System.out.println("Downloading Mongodb "+builder.toString()+" please wait.");
+                while ((n = input.read(buffer)) != -1) {
+                    out.write(buffer, 0, n);
+                    total += n;
+                }
+                out.flush();
+                out.close();
+                input.close();
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void help() {
+        //Does nothing.
+    }
+}


### PR DESCRIPTION
Solves: 1264 1268
Partially solves 1253 
Also:
* `upgrade` task will run the `update` 
* Better OS detection 
* Creating the `test-properties.properties` the file will not escape the URL
* Better support for the gradle task output console printing
* Windows Startup script for mongo will now check if the MSI is installed, if not it will download and unzip the zip version
* Download Until now can download any URL `java -jar crafter-utils.jar download URL`

Also now the unit test is not executed unless the param `-P"crafter.unittest` is set to true.
Script will get Windows build version and try to download the selenium driver for that build number (need to keep this updated)

Added: 
* `crafter.testing.chrome` which is the version of the wanted chrome driver default to `2.31`
* `crafter.testing.plataform`  OS that will test will run against (default to current os)
* `crafter.testing.browser` Which browser/selenium driver will be used.

