### PR TITLE
Fix util version, Minor fixes in crafter.sh

### DIFF
--- a/resources/crafter/crafter.sh
+++ b/resources/crafter/crafter.sh
@@ -54,8 +54,8 @@ function help() {
 
 
 function version(){
- echo "Crafter CMS Copyright \(C) 2007-2013 Crafter Software Corporation."
- echo "Version 3.0.3-SNAPSHOT-62a550"
+ echo "Copyright (C) 2007-2018 Crafter Software Corporation. All rights reserved."
+ echo "Version @VERSION@-@GIT_BUILD_ID@"
 }
 
 function manPages(){
@@ -754,7 +754,7 @@ case $1 in
   ;;
   start_solr)
   logo
-  startSolr36
+  startSolr
   ;;
   stop_solr)
   logo

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.craftercms</groupId>
     <artifactId>crafter-bundle-utils</artifactId>
-    <version>3.0.4-SNAPSHOT</version>
+    <version>3.0.8-SNAPSHOT</version>
     <name>Crafter Bundle Utils</name>
     <description>Crafter Bundle Utils</description>
     <url>https://github.com/craftercms/craftercms</url>


### PR DESCRIPTION
Fixes Util version.

crafter.sh
* calling directly `start_solr` now works.
* Hardcoded version number is now dynamic.