### PR TITLE
Updates for backup/restore tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -649,7 +649,7 @@ dependsOnOrdered(clean, cleanDeps)
 dependsOnOrdered(build, [clean] + buildDeps)
 dependsOnOrdered(init, initDeps)
 dependsOnOrdered(update, updateDeps)
-dependsOnOrdered(deploy, [preDeploy, downloadTomcat, downloadSolr, utils] + envDepends + deliveryDeps)
+dependsOnOrdered(deploy, [preDeploy, downloadTomcat, downloadSolr, downloadMariaDB4j, utils] + envDepends + deliveryDeps)
 dependsOnOrdered(upgrade, [update, preUpgrade, build, deploy])
 
 // If delivery no test (for now)

--- a/downloads.gradle
+++ b/downloads.gradle
@@ -115,6 +115,15 @@ task downloadChromeDriver(){
     }
 }
 
+task downloadMariaDB4j {
+  doFirst {
+    download {
+      src "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.craftercms.mariaDB4j&a=mariaDB4j-app&v=LATEST"
+      overwrite true
+      dest "${downloadDir}/mariaDB4j-app.jar"
+    }
+  }
+}
 
 def sha1(file){
     MessageDigest md = MessageDigest.getInstance("SHA1");

--- a/environments.gradle
+++ b/environments.gradle
@@ -246,6 +246,11 @@ envs.each { env ->
                 file("${path}/bin/solr-${solrVersion}").renameTo(file("${path}/bin/solr"))
 
             }
+            
+            copy {
+              from "$downloadDir/mariaDB4j-app.jar"
+              into "${path}/bin"
+            }
 
             copy {
                 from "./src/search/crafter-search-provider/solr/configsets"

--- a/resources/crafter/crafter.bat
+++ b/resources/crafter/crafter.bat
@@ -134,10 +134,10 @@ REM MySQL Dump
 IF EXIST "%MYSQL_DATA%" (
 	IF EXIST "%CRAFTER_BIN_FOLDER%dbms\bin\mysqldump.exe" (
 		echo "Adding MySQL dump"
-		start cmd /c %CRAFTER_BIN_FOLDER%dbms\bin\mysqldump.exe --databases crafter --port=@MARIADB_PORT@ --protocol=tcp --user=root ^> %TEMP_FOLDER%\crafter.sql
-		echo "SET GLOBAL innodb_large_prefix = TRUE ;\nSET GLOBAL innodb_file_format = 'BARRACUDA' ;\nSET GLOBAL innodb_file_format_max = 'BARRACUDA' ;\nSET GLOBAL innodb_file_per_table = TRUE ;\n" > temp.txt
-		type crafter.sql >> temp.txt
-		move /y temp.txt crafter.sql
+		start /w cmd /c %CRAFTER_BIN_FOLDER%dbms\bin\mysqldump.exe --databases crafter --port=33306 --protocol=tcp --user=root ^> %TEMP_FOLDER%\crafter.sql
+		echo SET GLOBAL innodb_large_prefix = TRUE ; SET GLOBAL innodb_file_format = 'BARRACUDA' ; SET GLOBAL innodb_file_format_max = 'BARRACUDA' ; SET GLOBAL innodb_file_per_table = TRUE ; > %TEMP_FOLDER%\temp.txt
+		type %TEMP_FOLDER%\crafter.sql >> %TEMP_FOLDER%\temp.txt
+		move /y %TEMP_FOLDER%\temp.txt %TEMP_FOLDER%\crafter.sql
 	)
 )
 
@@ -241,16 +241,16 @@ echo "Restoring Authoring Data"
 md "%MYSQL_DATA%"
 REM Start DB
 echo "Starting DB"
-start java -jar -DmariaDB4j.port=%MARIADB_PORT% -DmariaDB4j.baseDir=%CRAFTER_HOME%/dbms -DmariaDB4j.dataDir=%MYSQL_DATA% %CRAFTER_HOME%/mariaDB4j-app.jar
+start java -jar -DmariaDB4j.port=%MARIADB_PORT% -DmariaDB4j.baseDir=%CRAFTER_HOME%\dbms -DmariaDB4j.dataDir=%MYSQL_DATA% %CRAFTER_BIN_FOLDER%\mariaDB4j-app.jar
 timeout /nobreak /t 30
 REM Import
 echo "Restoring DB"
-start "MySQL Import" /W %CRAFTER_BIN_FOLDER%dbms\bin\mysql.exe --user=root --port=@MARIADB_PORT@ --protocol=TCP --binary-mode -e "source %TEMP_FOLDER%\crafter.sql"
+start /B /W %CRAFTER_BIN_FOLDER%dbms\bin\mysql.exe --user=root --port=33306 --protocol=TCP -e "source %TEMP_FOLDER%\crafter.sql"
 timeout /nobreak /t 5
 REM Stop DB
 echo "Stopping DB"
 set /p pid=<mariadb4j.pid
-taskkill /pid %pid%
+taskkill /pid %pid% /t /f
 timeout /nobreak /t 5
 :skipAuth
 

--- a/resources/crafter/crafter.bat
+++ b/resources/crafter/crafter.bat
@@ -135,6 +135,9 @@ IF EXIST "%MYSQL_DATA%" (
 	IF EXIST "%CRAFTER_BIN_FOLDER%dbms\bin\mysqldump.exe" (
 		echo "Adding MySQL dump"
 		start cmd /c %CRAFTER_BIN_FOLDER%dbms\bin\mysqldump.exe --databases crafter --port=@MARIADB_PORT@ --protocol=tcp --user=root ^> %TEMP_FOLDER%\crafter.sql
+		echo "SET GLOBAL innodb_large_prefix = TRUE ;\nSET GLOBAL innodb_file_format = 'BARRACUDA' ;\nSET GLOBAL innodb_file_format_max = 'BARRACUDA' ;\nSET GLOBAL innodb_file_per_table = TRUE ;\n" > temp.txt
+		type crafter.sql >> temp.txt
+		move /y temp.txt crafter.sql
 	)
 )
 
@@ -236,29 +239,23 @@ REM If it is an authoring env then sync the repos
 IF NOT EXIST "%TEMP_FOLDER%\crafter.sql" ( goto skipAuth )
 echo "Restoring Authoring Data"
 md "%MYSQL_DATA%"
-REM Install DB
-start "MySQL Installation" /W %CRAFTER_BIN_FOLDER%dbms\bin\mysql_install_db.exe --datadir="%MYSQL_DATA%"
 REM Start DB
-start "MySQL Server" %CRAFTER_BIN_FOLDER%dbms\bin\mysqld.exe --no-defaults --console --skip-grant-tables --max_allowed_packet=64M --basedir="%CRAFTER_BIN_FOLDER%dbms" --datadir="%MYSQL_DATA%" --port=@MARIADB_PORT@ --innodb_large_prefix=TRUE --innodb_file_format=BARRACUDA --innodb_file_format_max=BARRACUDA --innodb_file_per_table=TRUE
-timeout /nobreak /t 5
+echo "Starting DB"
+start java -jar -DmariaDB4j.port=%MARIADB_PORT% -DmariaDB4j.baseDir=%CRAFTER_HOME%/dbms -DmariaDB4j.dataDir=%MYSQL_DATA% %CRAFTER_HOME%/mariaDB4j-app.jar
+timeout /nobreak /t 30
 REM Import
-start "MySQL Import" /W %CRAFTER_BIN_FOLDER%dbms\bin\mysql.exe --user=root --port=@MARIADB_PORT@ -e "source %TEMP_FOLDER%\crafter.sql"
+echo "Restoring DB"
+start "MySQL Import" /W %CRAFTER_BIN_FOLDER%dbms\bin\mysql.exe --user=root --port=@MARIADB_PORT@ --protocol=TCP --binary-mode -e "source %TEMP_FOLDER%\crafter.sql"
 timeout /nobreak /t 5
 REM Stop DB
-taskkill /IM mysqld.exe
-REM start tomcat
-call :initWithOutExit
-echo "Waiting for studio to start"
-timeout /nobreak /t 120
-cd %CRAFTER_HOME%data\repos\sites
-FOR /D %%S in (*) do (
-  echo "Running sync for site '%%S'"
-  start /b /wait java -jar %CRAFTER_BIN_FOLDER%craftercms-utils.jar post "http://localhost:%TOMCAT_HTTP_PORT%/studio/api/1/services/api/1/repo/sync-from-repo.json" "{ \"site_id\":\"%%S\" }" true
-)
+echo "Stopping DB"
+set /p pid=<mariadb4j.pid
+taskkill /pid %pid%
+timeout /nobreak /t 5
 :skipAuth
 
 rd /S /Q "%TEMP_FOLDER%"
-echo "Restore completed"
+echo "Restore complete, you may now start the system"
 goto cleanOnExitKeepTermAlive
 
 

--- a/resources/crafter/crafter.sh
+++ b/resources/crafter/crafter.sh
@@ -593,6 +593,7 @@ function doBackup() {
       #Do dump
       echo "Adding mysql dump"
       $CRAFTER_HOME/dbms/bin/mysqldump --databases crafter --port=$MARIADB_PORT --protocol=tcp --user=root > "$TEMP_FOLDER/crafter.sql"
+      echo -e "SET GLOBAL innodb_large_prefix = TRUE ;\nSET GLOBAL innodb_file_format = 'BARRACUDA' ;\nSET GLOBAL innodb_file_format_max = 'BARRACUDA' ;\nSET GLOBAL innodb_file_per_table = TRUE ;\n$(cat $TEMP_FOLDER/crafter.sql)" > $TEMP_FOLDER/crafter.sql
     fi
   fi
 
@@ -687,27 +688,21 @@ attempt the restore. Are you sure you want to proceed? (yes/no) "
   # If it is an authoring env then sync the repos
   if [ -f "$TEMP_FOLDER/crafter.sql" ]; then
     mkdir "$MYSQL_DATA"
-    #Install DB
-    $CRAFTER_HOME/dbms/bin/mysql_install_db --datadir="$MYSQL_DATA" --basedir="$CRAFTER_HOME/dbms" --no-defaults --force --skip-name-resolve
     #Start DB
-    $CRAFTER_HOME/dbms/bin/mysqld --no-defaults --console --skip-grant-tables --max_allowed_packet=64M --basedir="$CRAFTER_HOME/dbms" --datadir="$MYSQL_DATA" --port=$MARIADB_PORT --pid="$CRAFTER_HOME/MariaDB4j.pid" --innodb_large_prefix=TRUE --innodb_file_format=BARRACUDA --innodb_file_format_max=BARRACUDA --innodb_file_per_table=TRUE &
-    sleep 5
+    echo "Starting DB"
+    java -jar -DmariaDB4j.port=$MARIADB_PORT -DmariaDB4j.baseDir="$CRAFTER_HOME/dbms" -DmariaDB4j.dataDir="$MYSQL_DATA" $CRAFTER_HOME/mariaDB4j-app.jar &
+    sleep 30
     # Import
-    $CRAFTER_HOME/dbms/bin/mysql --user=root --port=$MARIADB_PORT < "$TEMP_FOLDER/crafter.sql"
+    echo "Restoring DB"
+    $CRAFTER_HOME/dbms/bin/mysql --user=root --port=$MARIADB_PORT --protocol=TCP --binary-mode < "$TEMP_FOLDER/crafter.sql"
     # Stop DB
-    kill $(cat $CRAFTER_HOME/MariaDB4j.pid)
-    start
-    echo "Waiting for studio to start"
-    sleep 60
-    for SITE in $(ls $DEPLOYER_DEPLOYMENTS_DIR)
-    do
-      echo "Running sync for site $SITE"
-      java -jar $CRAFTER_HOME/craftercms-utils.jar post "http://localhost:$TOMCAT_HTTP_PORT/studio/api/1/services/api/1/repo/sync-from-repo.json" "{ \"site_id\":\"$SITE\" }" true
-    done
+    echo "Stopping DB"
+    kill $(cat mariadb4j.pid)
+    sleep 10
   fi
 
   rm -r "$TEMP_FOLDER"
-  echo "Restore completed"
+  echo "Restore complete, you may now start the system"
 }
 
 function logo() {

--- a/resources/crafter/crafter.sh
+++ b/resources/crafter/crafter.sh
@@ -682,7 +682,7 @@ attempt the restore. Are you sure you want to proceed? (yes/no) "
   # UNZIP deployer data
   echo "Restoring deployer data"
   rm -rf "$DEPLOYER_DATA_DIR/*"
-  java -jar craftercms-utils.jar unzip "$TEMP_FOLDER/deployer.zip" "$DEPLOYER_DATA_DIR"
+  java -jar $CRAFTER_HOME/craftercms-utils.jar unzip "$TEMP_FOLDER/deployer.zip" "$DEPLOYER_DATA_DIR"
 
   # If it is an authoring env then sync the repos
   if [ -f "$TEMP_FOLDER/crafter.sql" ]; then


### PR DESCRIPTION
#1991 
- MariaDB4j is used instead of running binaries directly
- Restore doesn't start crafter to sync sites anymore