### PR TITLE
Deploy task now downloads Grape dependencies:

### DIFF
--- a/environments.gradle
+++ b/environments.gradle
@@ -12,7 +12,6 @@ if (isWin) {
 /**
  Setup environment
  **/
-
 task("authoringPostEnvironment") {
     description "Setup the Crafter authoring environment"
 
@@ -116,9 +115,10 @@ task("authoringPostEnvironment") {
                 commandLine commandLinePrefix + ["chmod", "+x", "crafter.sh", "startup.sh", "debug.sh", "shutdown.sh", "crafter-setenv.sh"]
             }
         }
+
         updateCatalinaSettings(authEnv);
         updateTomcatPorts("${authEnv}/bin/apache-tomcat/conf/server.xml", authTomcatPort, authTomcatAJPPort,
-                authTomcatShutdownPort, authTomcatSSLPort)
+                          authTomcatShutdownPort, authTomcatSSLPort)
         updateTomcatContext("${authEnv}/bin/apache-tomcat/conf/context.xml")
         updateCatalinaLogging("${authEnv}/bin/apache-tomcat/conf/logging.properties")
         addSolrIndexHome("${authEnv}/bin/solr/server/solr/solr.xml")
@@ -193,7 +193,8 @@ task("deliveryPostEnvironment") {
             exec {
                 workingDir "${deliveryEnv}/bin/apache-tomcat/bin/"
                 commandLine commandLinePrefix + ["chmod", "+x", "catalina.sh", "setenv.sh", "configtest.sh", "daemon.sh",
-                                                 "digest.sh", "setclasspath.sh", "shutdown.sh", "startup.sh", "tool-wrapper.sh", "version.sh"]
+                                                 "digest.sh", "setclasspath.sh", "shutdown.sh", "startup.sh", "tool-wrapper.sh",
+                                                 "version.sh"]
             }
             exec {
                 workingDir "${deliveryEnv}/bin/crafter-deployer/"
@@ -207,11 +208,12 @@ task("deliveryPostEnvironment") {
         }
 
         updateTomcatPorts("${deliveryEnv}/bin/apache-tomcat/conf/server.xml", deliveryTomcatPort, deliveryTomcatAJPPort,
-                deliveryTomcatShutdownPort, deliveryTomcatSSLPort)
+                          deliveryTomcatShutdownPort, deliveryTomcatSSLPort)
         updateCatalinaSettings(deliveryEnv)
         updateTomcatContext("${deliveryEnv}/bin/apache-tomcat/conf/context.xml")
         updateCatalinaLogging("${deliveryEnv}/bin/apache-tomcat/conf/logging.properties")
         addSolrIndexHome("${deliveryEnv}/bin/solr/server/solr/solr.xml")
+        downloadGrapes(commandLinePrefix, "init-site.groovy")
     }
 }
 
@@ -305,6 +307,7 @@ envs.each { env ->
                     }
                 }
             }
+
             copy {
                 from "./src/studio/README.md"
                 into "${path}/bin/apache-tomcat"
@@ -327,6 +330,7 @@ envs.each { env ->
             }
         }
     }
+
     tasks.findByName("${env}Environment").finalizedBy("${env}PostEnvironment")
 }
 
@@ -385,5 +389,19 @@ def addSolrIndexHome(solrServerConfig) {
         def printer = new XmlNodePrinter(new PrintWriter(solrServerConfig))
         printer.preserveWhitespace = true
         printer.print(contextConfig)
+    }
+}
+
+/**
+ * Download Grape dependencies beforehand so that Groovy scripts can run without Internet connection. We do this by
+ * calling the script with -h to just print the help info
+ */
+def downloadGrapes(commandLinePrefix, groovyScript) {
+    exec {
+        workingDir "${deliveryEnv}/bin"
+        commandLine commandLinePrefix + ["groovy/bin/groovy", "-Dgrape.root=.", groovyScript, "-h"]
+        // ignore output
+        standardOutput = new ByteArrayOutputStream()
+        errorOutput = new ByteArrayOutputStream()
     }
 }

--- a/resources/crafter/init-site.bat
+++ b/resources/crafter/init-site.bat
@@ -5,4 +5,4 @@ SET DELIVERY_HOME=%~dp0
 call %DELIVERY_HOME%\crafter-setenv.bat
 
 REM Execute Groovy script
-%DELIVERY_HOME%\groovy\bin\groovy %DELIVERY_HOME%\init-site.groovy %*
+%DELIVERY_HOME%\groovy\bin\groovy -Dgrape.root=%DELIVERY_HOME% %DELIVERY_HOME%\init-site.groovy %*

--- a/resources/crafter/init-site.groovy
+++ b/resources/crafter/init-site.groovy
@@ -5,6 +5,7 @@
 		@Grab(group='commons-io', module='commons-io', version='2.6'),
 		@Grab(group='io.github.http-builder-ng', module='http-builder-ng-core', version='1.0.3')
 ])
+
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/resources/crafter/init-site.sh
+++ b/resources/crafter/init-site.sh
@@ -15,4 +15,4 @@ export DELIVERY_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "$DELIVERY_HOME/crafter-setenv.sh"
 
 # Execute Groovy script
-$DELIVERY_HOME/groovy/bin/groovy $DELIVERY_HOME/init-site.groovy "$@"
+$DELIVERY_HOME/groovy/bin/groovy -Dgrape.root=$DELIVERY_HOME $DELIVERY_HOME/init-site.groovy "$@"


### PR DESCRIPTION
* Added code to call init-site.groovy -h so that it downloads the dependencies and puts them under crafter-delivery/bin/grapes.
* The init-site.sh and init-site.bat will now call the Groovy script specifying crafter-delivery/bin/grapes as the Grapes root.

Ticket craftercms/craftercms#2169
