### PR TITLE
SSO logout fixes:

### DIFF
--- a/resources/tomcat-config/crafter/studio/extension/studio-config-override.yaml
+++ b/resources/tomcat-config/crafter/studio/extension/studio-config-override.yaml
@@ -110,15 +110,16 @@ studio.db.socket: /tmp/MariaDB4j.@MARIADB_PORT@.sock
 # studio.authentication.headers.lastName: lastname
 # Authentication header for email
 # studio.authentication.headers.email: email
-# Authentication header for groups: comma separated list of sites and groups
+# Authentication header for groups: comma separated list of groups
 #   Example:
-#   craftercms1645,Author,anothersite,Author
-# studio.authentication.headers.groups: groups
+#   site_author,site_xyz_developer
+studio.authentication.headers.groups: groups
 # Enable/disable logout for headers authenticated users (SSO)
-# studio.authentication.headers.logout.enabled: false
-# If logout is enabled for headers authenticated users (SSO), set the URL where SP (Service Provider) logout is provided
-# (to be called after local logout)
-# studio.authentication.headers.logout.url: /mellon/logout?RedirectTo={loginUrl}
+studio.authentication.headers.logout.enabled: false
+# If logout is enabled for headers authenticated users (SSO), set the endpoint of the SP or IdP logout, which should
+# be called after local logout. The {baseUrl} macro is provided so that the browser is redirected back to Studio
+# after logout (https://STUDIO_SERVER:STUDIO_PORT/studio)
+studio.authentication.headers.logout.url: /mellon/logout?ReturnTo={baseUrl}
 
 ##################################################
 ##        SMTP Configuration (Email)            ##

--- a/resources/tomcat-config/crafter/studio/extension/studio-config-override.yaml
+++ b/resources/tomcat-config/crafter/studio/extension/studio-config-override.yaml
@@ -113,13 +113,13 @@ studio.db.socket: /tmp/MariaDB4j.@MARIADB_PORT@.sock
 # Authentication header for groups: comma separated list of groups
 #   Example:
 #   site_author,site_xyz_developer
-studio.authentication.headers.groups: groups
+# studio.authentication.headers.groups: groups
 # Enable/disable logout for headers authenticated users (SSO)
-studio.authentication.headers.logout.enabled: false
+# studio.authentication.headers.logout.enabled: false
 # If logout is enabled for headers authenticated users (SSO), set the endpoint of the SP or IdP logout, which should
 # be called after local logout. The {baseUrl} macro is provided so that the browser is redirected back to Studio
 # after logout (https://STUDIO_SERVER:STUDIO_PORT/studio)
-studio.authentication.headers.logout.url: /mellon/logout?ReturnTo={baseUrl}
+# studio.authentication.headers.logout.url: /mellon/logout?ReturnTo={baseUrl}
 
 ##################################################
 ##        SMTP Configuration (Email)            ##


### PR DESCRIPTION
* Fixed SSO logout URL, default mod_auth_mellon param is ReturnTo.
* Changed {loginUrl} to {baseUrl} since in SSO it doesn't make sense to redirect to the Studio login page.

Ticket craftercms/craftercms#2500
