### PR TITLE
Fix for BouncyCastle provider permissions

### DIFF
--- a/resources/tomcat-config-delivery/catalina.policy
+++ b/resources/tomcat-config-delivery/catalina.policy
@@ -238,4 +238,6 @@ grant {
     permission java.io.FilePermission "${java.io.tmpdir}/-", "read, write, delete";
     permission java.io.FilePermission "/tmp/-", "read, write, delete";
     permission groovy.security.GroovyCodeSourcePermission "*";
+    permission java.security.SecurityPermission "putProviderProperty.BC";
+    permission java.security.SecurityPermission "insertProvider.BC";
 };

--- a/resources/tomcat-config/catalina.policy
+++ b/resources/tomcat-config/catalina.policy
@@ -238,6 +238,8 @@ grant {
     permission java.io.FilePermission "${java.io.tmpdir}/-", "read, write, delete";
     permission java.io.FilePermission "/tmp/-", "read, write, delete";
     permission groovy.security.GroovyCodeSourcePermission "*";
+    permission java.security.SecurityPermission "putProviderProperty.BC";
+    permission java.security.SecurityPermission "insertProvider.BC";
 };
 
 // Crafter Studio specific permissions


### PR DESCRIPTION
Missing permissions already added to `support/3.0.x`
