### PR TITLE
[3766] [studio-ui] Parameter "token" missing from call to /api/1/monitoring/log.json

### DIFF
--- a/resources/env/authoring/tomcat-config/crafter/studio/extension/studio-config-override.yaml
+++ b/resources/env/authoring/tomcat-config/crafter/studio/extension/studio-config-override.yaml
@@ -28,7 +28,19 @@ studio.configuration.management.authorizationToken: ${env:STUDIO_MANAGEMENT_TOKE
 # Preview engine management authorization token.
 # Please update this per installation and provide this token to the status monitors.
 studio.configuration.management.previewAuthorizationToken: ${env:ENGINE_MANAGEMENT_TOKEN}
-
+# Protected URLs with preview engine management authorization token.
+# Coma separated list of preview engine urls
+studio.configuration.management.previewProtectedUrls: >-
+  /api/1/monitoring/log.json,
+  /api/1/monitoring/memory.json,
+  /api/1/monitoring/status.json,
+  /api/1/monitoring/version.json,
+  /api/1/site/context/id,
+  /api/1/site/context/destroy,
+  /api/1/site/context/rebuild,
+  /api/1/site/context/graphql/rebuild,
+  /api/1/site/cache/clear,
+  /api/1/site/cache/statistics
 ############################################################
 ##                    Preview Deployer                    ##
 ############################################################


### PR DESCRIPTION
Added studio proxy controller configuration

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/3766