### PR TITLE
Update comments for management tokens

### DIFF
--- a/resources/deployer/config/application.yaml
+++ b/resources/deployer/config/application.yaml
@@ -13,7 +13,6 @@ deployer:
       folderPath: ${logs.dir}
     management:
       # Deployer management authorization token
-      # Please update this per installation and provide this token to the status monitors.
       authorizationToken: ${DEPLOYER_MANAGEMENT_TOKEN}
     security:
       encryption:

--- a/resources/env/authoring/bin/crafter-setenv.sh
+++ b/resources/env/authoring/bin/crafter-setenv.sh
@@ -119,6 +119,7 @@ export CRAFTER_APPLICATION_LOGS=${CRAFTER_APPLICATION_LOGS:="$CATALINA_LOGS_DIR"
 export GIT_CONFIG_NOSYSTEM=${GIT_CONFIG_NOSYSTEM:="true"}
 
 # -------------------- Management tokens ----------------
+# Please update this per installation and provide this token to the status monitors.
 export STUDIO_MANAGEMENT_TOKEN=${STUDIO_MANAGEMENT_TOKEN:="defaultManagementToken"}
 export ENGINE_MANAGEMENT_TOKEN=${ENGINE_MANAGEMENT_TOKEN:="defaultManagementToken"}
 export DEPLOYER_MANAGEMENT_TOKEN=${DEPLOYER_MANAGEMENT_TOKEN:="defaultManagementToken"}
@@ -127,8 +128,8 @@ export PROFILE_MANAGEMENT_TOKEN=${PROFILE_MANAGEMENT_TOKEN:="defaultManagementTo
 export SOCIAL_MANAGEMENT_TOKEN=${SOCIAL_MANAGEMENT_TOKEN:="defaultManagementToken"}
 
 # -------------------- Encryption variables --------------------
-export CRAFTER_ENCRYPTION_KEY=${CRAFTER_ENCRYPTION_KEY:="default_encrytption_key"}
-export CRAFTER_ENCRYPTION_SALT=${CRAFTER_ENCRYPTION_SALT:="default_encrytption_salt"}
+export CRAFTER_ENCRYPTION_KEY=${CRAFTER_ENCRYPTION_KEY:="default_encryption_key"}
+export CRAFTER_ENCRYPTION_SALT=${CRAFTER_ENCRYPTION_SALT:="default_encryption_salt"}
 
 # -------------------- Cluster variables --------------------
 export CLUSTER_NODE_ADDRESS=${CLUSTER_NODE_ADDRESS:="127.0.0.1"}

--- a/resources/env/authoring/bin/crafter-setenv.sh
+++ b/resources/env/authoring/bin/crafter-setenv.sh
@@ -119,7 +119,7 @@ export CRAFTER_APPLICATION_LOGS=${CRAFTER_APPLICATION_LOGS:="$CATALINA_LOGS_DIR"
 export GIT_CONFIG_NOSYSTEM=${GIT_CONFIG_NOSYSTEM:="true"}
 
 # -------------------- Management tokens ----------------
-# Please update this per installation and provide this token to the status monitors.
+# Please update this per installation and provide these tokens to the status monitors.
 export STUDIO_MANAGEMENT_TOKEN=${STUDIO_MANAGEMENT_TOKEN:="defaultManagementToken"}
 export ENGINE_MANAGEMENT_TOKEN=${ENGINE_MANAGEMENT_TOKEN:="defaultManagementToken"}
 export DEPLOYER_MANAGEMENT_TOKEN=${DEPLOYER_MANAGEMENT_TOKEN:="defaultManagementToken"}

--- a/resources/env/authoring/tomcat-config/crafter/engine/extension/server-config.properties
+++ b/resources/env/authoring/tomcat-config/crafter/engine/extension/server-config.properties
@@ -14,7 +14,6 @@ crafter.engine.elasticsearch.username=${ES_USERNAME}
 crafter.engine.elasticsearch.password=${ES_PASSWORD}
 
 # Engine management authorization token
-# Please update this per installation and provide this token to the status monitors.
 crafter.engine.management.authorizationToken=${ENGINE_MANAGEMENT_TOKEN}
 
 # The key used for encryption of configuration properties

--- a/resources/env/authoring/tomcat-config/crafter/profile/extension/server-config.properties
+++ b/resources/env/authoring/tomcat-config/crafter/profile/extension/server-config.properties
@@ -1,4 +1,4 @@
 crafter.profile.mongodb.connection.newConnectionStr=mongodb://${MONGODB_HOST}:${MONGODB_PORT}/crafterprofile?readPreference=primary\
                                                    &maxPoolSize=150&minPoolSize=50&maxIdleTimeMS=1000&waitQueueMultiple=200&waitQueueTimeoutMS=1000&w=1&journal=true
-
+# Profile management authorization token
 crafter.profile.management.authorizationToken=${PROFILE_MANAGEMENT_TOKEN}

--- a/resources/env/authoring/tomcat-config/crafter/search/extension/server-config.properties
+++ b/resources/env/authoring/tomcat-config/crafter/search/extension/server-config.properties
@@ -1,4 +1,3 @@
 crafter.search.solr.server.url=${SOLR_URL}
 # Search management authorization token
-# Please update this per installation and provide this token to the status monitors.
 crafter.search.management.authorizationToken=${SEARCH_MANAGEMENT_TOKEN}

--- a/resources/env/authoring/tomcat-config/crafter/social/extension/social.properties
+++ b/resources/env/authoring/tomcat-config/crafter/social/extension/social.properties
@@ -1,5 +1,5 @@
 studio.social.mongodb.connection.newConnectionStr=mongodb://${MONGODB_HOST}:${MONGODB_PORT}/craftersocial?readPreference=primary\
   &maxPoolSize=150&minPoolSize=50&maxIdleTimeMS=1000&waitQueueMultiple=200&waitQueueTimeoutMS=1000&w=1&journal=true
 crafter.profile.rest.client.url.base=${PROFILE_URL}
-
+# Social management authorization token
 crafter.social.management.authorizationToken=${SOCIAL_MANAGEMENT_TOKEN}

--- a/resources/env/authoring/tomcat-config/crafter/studio/extension/studio-config-override.yaml
+++ b/resources/env/authoring/tomcat-config/crafter/studio/extension/studio-config-override.yaml
@@ -23,10 +23,8 @@ studio.configuration.site.defaultAuthoringUrl: ^https?://localhost:8080/studio/?
 # Default GraphQL server URL
 studio.configuration.site.defaultGraphqlServerUrl: ^https?://localhost:8080/?
 # Studio management authorization token.
-# Please update this per installation and provide this token to the status monitors.
 studio.configuration.management.authorizationToken: ${env:STUDIO_MANAGEMENT_TOKEN}
 # Preview engine management authorization token.
-# Please update this per installation and provide this token to the status monitors.
 studio.configuration.management.previewAuthorizationToken: ${env:ENGINE_MANAGEMENT_TOKEN}
 # Protected URLs with preview engine management authorization token.
 # Coma separated list of preview engine urls

--- a/resources/env/delivery/bin/crafter-setenv.sh
+++ b/resources/env/delivery/bin/crafter-setenv.sh
@@ -91,6 +91,7 @@ export CATALINA_TMPDIR=${CATALINA_TMPDIR:="$CRAFTER_TEMP_DIR/tomcat"}
 export GIT_CONFIG_NOSYSTEM=${GIT_CONFIG_NOSYSTEM:="true"}
 
 # -------------------- Management tokens ----------------
+# Please update this per installation and provide this token to the status monitors.
 export ENGINE_MANAGEMENT_TOKEN=${ENGINE_MANAGEMENT_TOKEN:="defaultManagementToken"}
 export DEPLOYER_MANAGEMENT_TOKEN=${DEPLOYER_MANAGEMENT_TOKEN:="defaultManagementToken"}
 export SEARCH_MANAGEMENT_TOKEN=${SEARCH_MANAGEMENT_TOKEN:="defaultManagementToken"}
@@ -98,5 +99,5 @@ export PROFILE_MANAGEMENT_TOKEN=${PROFILE_MANAGEMENT_TOKEN:="defaultManagementTo
 export SOCIAL_MANAGEMENT_TOKEN=${SOCIAL_MANAGEMENT_TOKEN:="defaultManagementToken"}
 
 # -------------------- Encryption variables --------------------
-export CRAFTER_ENCRYPTION_KEY=${CRAFTER_ENCRYPTION_KEY:="default_encrytption_key"}
-export CRAFTER_ENCRYPTION_SALT=${CRAFTER_ENCRYPTION_SALT:="default_encrytption_salt"}
+export CRAFTER_ENCRYPTION_KEY=${CRAFTER_ENCRYPTION_KEY:="default_encryption_key"}
+export CRAFTER_ENCRYPTION_SALT=${CRAFTER_ENCRYPTION_SALT:="default_encryption_salt"}

--- a/resources/env/delivery/tomcat-config/crafter/engine/extension/server-config.properties
+++ b/resources/env/delivery/tomcat-config/crafter/engine/extension/server-config.properties
@@ -24,7 +24,6 @@ crafter.engine.elasticsearch.password=${ES_PASSWORD}
 # crafter.engine.s3.secretKey=
 
 # Engine management authorization token
-# Please update this per installation and provide this token to the status monitors.
 crafter.engine.management.authorizationToken=${ENGINE_MANAGEMENT_TOKEN}
 
 # The key used for encryption of configuration properties

--- a/resources/env/delivery/tomcat-config/crafter/profile/extension/server-config.properties
+++ b/resources/env/delivery/tomcat-config/crafter/profile/extension/server-config.properties
@@ -1,4 +1,4 @@
 crafter.profile.mongodb.connection.newConnectionStr=mongodb://${MONGODB_HOST}:${MONGODB_PORT}/crafterprofile?readPreference=primary\
                                                    &maxPoolSize=150&minPoolSize=50&maxIdleTimeMS=1000&waitQueueMultiple=200&waitQueueTimeoutMS=1000&w=1&journal=true
-
+# Profile management authorization token
 crafter.profile.management.authorizationToken=${PROFILE_MANAGEMENT_TOKEN}

--- a/resources/env/delivery/tomcat-config/crafter/search/extension/server-config.properties
+++ b/resources/env/delivery/tomcat-config/crafter/search/extension/server-config.properties
@@ -1,4 +1,3 @@
 crafter.search.solr.server.url=${SOLR_URL}
 # Search management authorization token
-# Please update this per installation and provide this token to the status monitors.
 crafter.search.management.authorizationToken=${SEARCH_MANAGEMENT_TOKEN}

--- a/resources/env/delivery/tomcat-config/crafter/social/extension/social.properties
+++ b/resources/env/delivery/tomcat-config/crafter/social/extension/social.properties
@@ -1,5 +1,5 @@
 studio.social.mongodb.connection.newConnectionStr=mongodb://${MONGODB_HOST}:${MONGODB_PORT}/craftersocial?readPreference=primary\
   &maxPoolSize=150&minPoolSize=50&maxIdleTimeMS=1000&waitQueueMultiple=200&waitQueueTimeoutMS=1000&w=1&journal=true
 crafter.profile.rest.client.url.base=${PROFILE_URL}
-
+# Social management authorization token
 crafter.social.management.authorizationToken=${SOCIAL_MANAGEMENT_TOKEN}


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Update comments for management tokens: 
- Remove comment `# Please update this per installation and provide this token to the status monitors.` and place comment in `crafter-setenv.sh` instead to make it obvious that they should only change the value there in `crafter-setenv.sh`
- Add comment `# XXX management authorization token`, where `XXX` is module name to make all files consistent

Fix typo in default value of encryption salt and key

