### PR TITLE
Set default OpenSearch max_clause_count to 8k

### DIFF
--- a/environments.gradle
+++ b/environments.gradle
@@ -510,6 +510,8 @@ ext.commonConfUpdatePatterns = [
                 replace: '# ---------------------------------- Various -----------------------------------' +
                         System.lineSeparator() +
                         'plugins.security.disabled: true' + System.lineSeparator() + 'plugins.sql.enabled: false' +
+                        System.lineSeparator() +
+                        'indices.query.bool.max_clause_count: 8192' +
                         System.lineSeparator()
             ]
         ]


### PR DESCRIPTION
Set default OpenSearch max_clause_count to 8k
https://github.com/craftersoftware/craftercms/issues/786