### PR TITLE
OpenSearch version for Mac OSX is now wired to Gradle Properties

### DIFF
--- a/environments.gradle
+++ b/environments.gradle
@@ -599,7 +599,8 @@ def authoringTokens = [
   VERSION              : project.version,
   GIT_BUILD_ID         : gitRevisionId,
   SMTP_PORT            : String.valueOf(authoringSmtpPort),
-  MARIADB_VERSION      : String.valueOf(mariaDbVersion)
+  MARIADB_VERSION      : String.valueOf(mariaDbVersion),
+  SEARCH_VERSION       : String.valueOf(openSearchVersion)
 ]
 
 def deliveryTokens = [
@@ -616,7 +617,8 @@ def deliveryTokens = [
   ENV                  : "delivery",
   VERSION              : project.version,
   GIT_BUILD_ID         : gitRevisionId,
-  SMTP_PORT            : String.valueOf(deliverySmtpPort)
+  SMTP_PORT            : String.valueOf(deliverySmtpPort),
+  SEARCH_VERSION       : String.valueOf(openSearchVersion)
 ]
 
 ext.getEnvironments = { ->

--- a/resources/bin/crafter.sh
+++ b/resources/bin/crafter.sh
@@ -885,11 +885,13 @@ function stopDeployer() {
 }
 
 function createOpenSearchDocker() {
+  searchVersion="@SEARCH_VERSION@"
+
   if docker inspect "$SEARCH_DOCKER_NAME" > /dev/null 2>&1; then
     cecho "Docker image $SEARCH_DOCKER_NAME found, unable to start. Please remove this image before starting.\n To remove the image, run: docker rm $SEARCH_DOCKER_NAME\n" "error"
     exit 21
   else
-    docker create -p $SEARCH_PORT:9200 -e "discovery.type=single-node" -e "DISABLE_SECURITY_PLUGIN=true" -v "$SEARCH_INDEXES_DIR":/usr/share/opensearch/data/ --name "$SEARCH_DOCKER_NAME" opensearchproject/opensearch:2.15.0 > /dev/null 2>&1
+    docker create -p $SEARCH_PORT:9200 -e "discovery.type=single-node" -e "DISABLE_SECURITY_PLUGIN=true" -v "$SEARCH_INDEXES_DIR":/usr/share/opensearch/data/ --name "$SEARCH_DOCKER_NAME" opensearchproject/opensearch:$searchVersion > /dev/null 2>&1
   fi
 }
 


### PR DESCRIPTION
Made OpenSearch version propagate from gradle properties to the crafter.sh shell script for Mac OSX OpenSearch docker image launch.
