### PR TITLE
Migrate to the new Central Portal Publisher Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
 		<studio.ui.node.version>v21.7.3</studio.ui.node.version>
 		<studio.ui.yarn.version>v1.22.22</studio.ui.yarn.version>
 		<exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>
-		<nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+		<central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
 		<cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
 	</properties>
 
@@ -1172,22 +1172,14 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>${nexus-staging-maven-plugin.version}</version>
-						<executions>
-							<execution>
-								<id>default-deploy</id>
-								<phase>deploy</phase>
-								<goals>
-									<goal>deploy</goal>
-								</goals>
-							</execution>
-						</executions>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>${central-publishing-maven-plugin.version}</version>
+						<extensions>true</extensions>
 						<configuration>
-							<serverId>central-releases</serverId>
-							<nexusUrl>https://central.sonatype.com/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+							<publishingServerId>central-releases</publishingServerId>
+							<autoPublish>true</autoPublish>
+							<deploymentName>${project.artifactId}-${project.version}</deploymentName>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -1216,9 +1208,5 @@
 			<id>central-snapshots</id>
 			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 		</snapshotRepository>
-		<repository>
-			<id>central-releases</id>
-			<url>https://central.sonatype.com/repository/maven-releases/</url>
-		</repository>
 	</distributionManagement>
 </project>

--- a/shared-dependencies/pom.xml
+++ b/shared-dependencies/pom.xml
@@ -81,7 +81,7 @@
 
 		<maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
 		<maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-		<nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+		<central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -540,22 +540,14 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>${nexus-staging-maven-plugin.version}</version>
-						<executions>
-							<execution>
-								<id>default-deploy</id>
-								<phase>deploy</phase>
-								<goals>
-									<goal>deploy</goal>
-								</goals>
-							</execution>
-						</executions>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>${central-publishing-maven-plugin.version}</version>
+						<extensions>true</extensions>
 						<configuration>
-							<serverId>central-releases</serverId>
-							<nexusUrl>https://central.sonatype.com/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+							<publishingServerId>central-releases</publishingServerId>
+							<autoPublish>true</autoPublish>
+							<deploymentName>${project.artifactId}-${project.version}</deploymentName>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -584,9 +576,5 @@
 			<id>central-snapshots</id>
 			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 		</snapshotRepository>
-		<repository>
-			<id>central-releases</id>
-			<url>https://central.sonatype.com/repository/maven-releases/</url>
-		</repository>
 	</distributionManagement>
 </project>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -86,7 +86,7 @@
 		<maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
 		<maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
 		<buildnumber-maven-plugin.version>3.2.1</buildnumber-maven-plugin.version>
-		<nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+		<central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
 		<cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
 	</properties>
 
@@ -296,22 +296,14 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>${nexus-staging-maven-plugin.version}</version>
-						<executions>
-							<execution>
-								<id>default-deploy</id>
-								<phase>deploy</phase>
-								<goals>
-									<goal>deploy</goal>
-								</goals>
-							</execution>
-						</executions>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>${central-publishing-maven-plugin.version}</version>
+						<extensions>true</extensions>
 						<configuration>
-							<serverId>central-releases</serverId>
-							<nexusUrl>https://central.sonatype.com/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+							<publishingServerId>central-releases</publishingServerId>
+							<autoPublish>true</autoPublish>
+							<deploymentName>${project.artifactId}-${project.version}</deploymentName>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -340,9 +332,5 @@
 			<id>central-snapshots</id>
 			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 		</snapshotRepository>
-		<repository>
-			<id>central-releases</id>
-			<url>https://central.sonatype.com/repository/maven-releases/</url>
-		</repository>
 	</distributionManagement>
 </project>


### PR DESCRIPTION
### Ticket reference or the full description of what's in the PR
https://github.com/craftercms/craftercms/issues/8087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Maven configuration to use the new Central Publishing plugin for artifact deployment.
  - Streamlined publishing settings and removed the central releases repository entry from distribution management.
  - Adjusted plugin parameters for improved publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->