### PR TITLE
Rollback log4j version upgrade due to build failures

### DIFF
--- a/shared-dependencies/pom.xml
+++ b/shared-dependencies/pom.xml
@@ -62,7 +62,7 @@
 		<commons-configuration2.version>2.12.0</commons-configuration2.version>
 		<commons-io.version>2.19.0</commons-io.version>
 		<commons-csv.version>1.14.0</commons-csv.version>
-		<log4j2.version>2.25.0</log4j2.version>
+		<log4j2.version>2.24.3</log4j2.version>
 		<angus-mail.version>2.0.3</angus-mail.version>
 		<jakarta-mail-api.version>2.1.3</jakarta-mail-api.version>
 		<junit-vintage.version>5.13.1</junit-vintage.version>


### PR DESCRIPTION
Rollback log4j version upgrade due to build failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of a logging library dependency used by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->