### PR TITLE
Increase timeout for creating deployer target in init-site for Mac with apple silicon #8263

### DIFF
--- a/resources/env/delivery/bin/init-site.groovy
+++ b/resources/env/delivery/bin/init-site.groovy
@@ -131,7 +131,11 @@ def validateRepoPath(cli, repoPath) {
 def createDeployerTarget(siteName, repoPath, targetParams) {
     println 'Creating Deployer Target...'
 
-    OkHttpClient client = new OkHttpClient()
+    OkHttpClient client = new OkHttpClient.Builder()
+            .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+            .writeTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+            .build()
     MediaType mediaType = MediaType.parse('application/json')
     RequestBody body = RequestBody.create(new JsonBuilder(targetParams).toString(), mediaType)
     Request request = new Request.Builder()


### PR DESCRIPTION
### Ticket reference or the full description of what's in the PR
Increase timeout for creating deployer target in init-site for Mac with apple silicon https://github.com/craftercms/craftercms/issues/8263