### PR TITLE
Upgrade MariaDB4j

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ openSearchVersion=2.19.3
 mongodbVersion=8.0.1
 mongoshVersion=1.8.0
 mongoToolsVersion=100.10.0
-mariadb4jVersion=3.1.0.4
+mariadb4jVersion=3.1.0.5
 undercouchDownloadVersion=5.6.0
 mariaDbVersion=11.4.3
 # Dependency Versions

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 		<graphql-java-extended-scalars.version>24.0</graphql-java-extended-scalars.version>
 		<smiley-http-proxy-servlet.version>2.0</smiley-http-proxy-servlet.version>
 		<tinify.version>1.8.8</tinify.version>
-		<mariadb4j.version>3.1.0.4</mariadb4j.version>
+		<mariadb4j.version>3.1.0.5</mariadb4j.version>
 		<Saxon-HE.version>12.8</Saxon-HE.version>
 		<cxf-rt.version>4.1.3</cxf-rt.version>
 		<ibatis-sqlmap.version>2.3.4.726</ibatis-sqlmap.version>


### PR DESCRIPTION
### Ticket reference or the full description of what's in the PR
https://github.com/craftersoftware/craftercms/issues/1160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated MariaDB4j dependency from 3.1.0.4 to 3.1.0.5 across build configurations (Gradle and Maven) to keep versions aligned.
  - Affects the embedded database used in local/test environments; no changes to production features or behavior.
  - No UI or functional updates; this is a dependency version bump only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->