### PR TITLE
Upgrade to Groovy 5. Update whitelists

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Versions
 # Main Versions
 org.gradle.daemon=true
-groovyVersion=4.0.28
+groovyVersion=5.0.2
 tomcatVersion=11.0.8
 tomcatMajorVersion=11
 openSearchVersion=3.3.2

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<project.test.sourceEncoding>UTF-8</project.test.sourceEncoding>
 		<tomcat.version>11.0.10</tomcat.version>
 		<java.version>21</java.version>
-		<groovy.version>4.0.28</groovy.version>
+		<groovy.version>5.0.2</groovy.version>
 		<jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
 		<jakarta.servlet.jsp-api.version>4.0.0</jakarta.servlet.jsp-api.version>
 		<jakarta.servlet.jsp.jstl-api.version>3.0.2</jakarta.servlet.jsp.jstl-api.version>

--- a/resources/env/authoring/tomcat-config/crafter/engine/extension/groovy/whitelist
+++ b/resources/env/authoring/tomcat-config/crafter/engine/extension/groovy/whitelist
@@ -1426,7 +1426,7 @@ method org.opensearch.client.opensearch._types.query_dsl.MatchQuery$Builder quer
 method org.opensearch.client.opensearch._types.query_dsl.Query$Builder bool java.util.function.Function
 method org.opensearch.client.opensearch._types.query_dsl.Query$Builder match java.util.function.Function
 method org.opensearch.client.opensearch._types.query_dsl.Query$Builder term java.util.function.Function
-method org.opensearch.client.opensearch._types.query_dsl.QueryVariant _toQuery
+method org.opensearch.client.opensearch._types.query_dsl.QueryVariant toQuery
 method org.opensearch.client.opensearch.core.SearchRequest$Builder from java.lang.Integer
 method org.opensearch.client.opensearch.core.SearchRequest$Builder highlight org.opensearch.client.opensearch.core.search.Highlight
 method org.opensearch.client.opensearch.core.SearchRequest$Builder query java.util.function.Function

--- a/resources/env/delivery/tomcat-config/crafter/engine/extension/groovy/whitelist
+++ b/resources/env/delivery/tomcat-config/crafter/engine/extension/groovy/whitelist
@@ -1426,7 +1426,7 @@ method org.opensearch.client.opensearch._types.query_dsl.MatchQuery$Builder quer
 method org.opensearch.client.opensearch._types.query_dsl.Query$Builder bool java.util.function.Function
 method org.opensearch.client.opensearch._types.query_dsl.Query$Builder match java.util.function.Function
 method org.opensearch.client.opensearch._types.query_dsl.Query$Builder term java.util.function.Function
-method org.opensearch.client.opensearch._types.query_dsl.QueryVariant _toQuery
+method org.opensearch.client.opensearch._types.query_dsl.QueryVariant toQuery
 method org.opensearch.client.opensearch.core.SearchRequest$Builder from java.lang.Integer
 method org.opensearch.client.opensearch.core.SearchRequest$Builder highlight org.opensearch.client.opensearch.core.search.Highlight
 method org.opensearch.client.opensearch.core.SearchRequest$Builder query java.util.function.Function

--- a/shared-dependencies/pom.xml
+++ b/shared-dependencies/pom.xml
@@ -75,7 +75,7 @@
 		<jackson.version>2.19.2</jackson.version>
 		<aws.sdk.version>2.32.25</aws.sdk.version>
 		<jose4j.version>0.9.6</jose4j.version>
-		<groovy.version>4.0.28</groovy.version>
+		<groovy.version>5.0.2</groovy.version>
 		<ivy.version>2.5.3</ivy.version>
 		<quartz.version>2.5.0</quartz.version>
 


### PR DESCRIPTION
Upgrade to Groovy 5
Upgrade to OpenSearch 3.3: Update whitelists
https://github.com/craftercms/craftercms/issues/8390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Groovy dependency to version 5.0.2.
  * Adjusted several public search-related API signatures (renames and new overloads) — may require integration review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->