### PR TITLE
Drop upgrade hooks from version < 4.x

### DIFF
--- a/resources/bin/upgrade/hooks/PostUpgradeHooks.groovy
+++ b/resources/bin/upgrade/hooks/PostUpgradeHooks.groovy
@@ -25,25 +25,6 @@ import upgrade.exceptions.UpgradeException
 
 class PostUpgradeHooks {
 
-	private static final List<PostUpgradeHook> AUTHORING_3_1_X_NO_DB_HOOKS = [
-		new StartCrafterHook(),
-		new RecreateIndexesHook(),
-		new PostUpgradeCompletedHook(true)
-	]
-
-	private static final List<PostUpgradeHook> AUTHORING_3_1_X_WITH_DB_HOOKS = [
-		new UpgradeEmbeddedDbHook(),
-		new StartCrafterHook(),
-		new RecreateIndexesHook(),
-		new PostUpgradeCompletedHook(true)
-	]
-
-	private static final List<PostUpgradeHook> DELIVERY_3_1_X_HOOKS = [
-		new StartCrafterHook(),
-		new RecreateIndexesHook(),
-		new PostUpgradeCompletedHook(true)
-	]
-
 	private static final List<PostUpgradeHook> AUTHORING_4_0_X = [
 		new MakePublishedRepoBareHook(),
 		new RemoveOldSearchIndexesDirHook(),
@@ -73,19 +54,11 @@ class PostUpgradeHooks {
 	private static final Map ALL_HOOKS = [
 		'authoring': [
 			'>=4.1.0'     : AUTHORING_4_1_x,
-			'4.0'         : AUTHORING_4_0_X,
-			'3.1.9'       : AUTHORING_3_1_X_WITH_DB_HOOKS,
-			'3.1.12'      : AUTHORING_3_1_X_WITH_DB_HOOKS,
-			'3.1.13'      : AUTHORING_3_1_X_WITH_DB_HOOKS,
-			'3.1 >=3.1.17': AUTHORING_3_1_X_NO_DB_HOOKS
+			'4.0'         : AUTHORING_4_0_X
 		],
 		'delivery' : [
 			'>=4.1.0'     : DELIVERY_4_1_x,
-			'4.0'         : DELIVERY_4_0_X,
-			'3.1.9'       : DELIVERY_3_1_X_HOOKS,
-			'3.1.12'      : DELIVERY_3_1_X_HOOKS,
-			'3.1.13'      : DELIVERY_3_1_X_HOOKS,
-			'3.1 >=3.1.17': DELIVERY_3_1_X_HOOKS
+			'4.0'         : DELIVERY_4_0_X
 		]
 	]
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8326
Drop upgrade hooks from version < 4.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified upgrade path logic by removing legacy upgrade support for versions prior to 4.1.0. System now supports upgrades only from version 4.1.0 and later. Deprecated upgrade configurations have been cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->