### PR TITLE
Ignore major version dependency updates in 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,7 +63,7 @@ updates:
             -   dependency-name: "org.mybatis:mybatis-spring"
                 versions: [ ">=4.0.0" ]
             -   dependency-name: "org.junit.jupiter:junit-jupiter-engine"
-                versions: [ ">=5.0.0" ]
+                versions: [ ">=6.0.0" ]
 
     -   package-ecosystem: "gradle"
         directories:
@@ -128,4 +128,4 @@ updates:
             -   dependency-name: "org.mybatis:mybatis-spring"
                 versions: [ ">=4.0.0" ]
             -   dependency-name: "org.junit.jupiter:junit-jupiter-engine"
-                versions: [ ">=5.0.0" ]
+                versions: [ ">=6.0.0" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,20 @@ updates:
                 versions: [ ">=5.0.0" ]
             -   dependency-name: "org.apache.groovy:groovy-sql"
                 versions: [ ">=5.0.0" ]
+            -   dependency-name: "org.springframework.boot:*"
+                versions: [ ">=4.0.0" ]
+            -   dependency-name: "org.springframework:*"
+                versions: [ ">=7.0.0" ]
+            -   dependency-name: "org.springframework.security:*"
+                versions: [ ">=7.0.0" ]
+            -   dependency-name: "org.springframework.data:*"
+                versions: [ ">=4.0.0" ]
+            -   dependency-name: "org.springframework.ldap:*"
+                versions: [ ">=4.0.0" ]
+            -   dependency-name: "org.mybatis:mybatis-spring"
+                versions: [ ">=4.0.0" ]
+            -   dependency-name: "org.junit.jupiter:junit-jupiter-engine"
+                versions: [ ">=5.0.0" ]
 
     -   package-ecosystem: "gradle"
         directories:
@@ -100,4 +114,18 @@ updates:
             -   dependency-name: "org.apache.groovy:groovy-all"
                 versions: [ ">=5.0.0" ]
             -   dependency-name: "org.apache.groovy:groovy-sql"
+                versions: [ ">=5.0.0" ]
+            -   dependency-name: "org.springframework.boot:*"
+                versions: [ ">=4.0.0" ]
+            -   dependency-name: "org.springframework:*"
+                versions: [ ">=7.0.0" ]
+            -   dependency-name: "org.springframework.security:*"
+                versions: [ ">=7.0.0" ]
+            -   dependency-name: "org.springframework.data:*"
+                versions: [ ">=4.0.0" ]
+            -   dependency-name: "org.springframework.ldap:*"
+                versions: [ ">=4.0.0" ]
+            -   dependency-name: "org.mybatis:mybatis-spring"
+                versions: [ ">=4.0.0" ]
+            -   dependency-name: "org.junit.jupiter:junit-jupiter-engine"
                 versions: [ ">=5.0.0" ]


### PR DESCRIPTION
Ignore major version dependency updates in 4.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency-update configuration to add automated updates for Spring ecosystem libraries and the JUnit engine, broadening version constraints to keep dependencies current and improve maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->