### PR TITLE
Fix httpclient5 and netty version for spring boot pom

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -75,7 +75,8 @@
 		<spring-boot.version>4.0.1</spring-boot.version>
 
 		<!-- Override property setup by Spring Boot Parent -->
-		<netty.version>4.1.118.Final</netty.version>
+		<netty.version>4.2.9.Final</netty.version>
+		<httpclient5.version>5.6</httpclient5.version>
 
 		<!-- Testing -->
 


### PR DESCRIPTION
Fix httpclient5 and netty version for spring boot pom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Netty library to improve application performance, security, and stability
  * Added HTTP Client 5 library support for enhanced request handling and network capabilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->