### PR TITLE
Don't show server info in error response

### DIFF
--- a/environments.gradle
+++ b/environments.gradle
@@ -263,6 +263,10 @@ ext.commonConfUpdatePatterns = [
 			[
 				match  : 'logs',
 				replace: '${catalina.logs}'
+			],
+			[
+				match  : "<!-- SingleSignOn valve, share authentication between web applications",
+				replace: '<Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="true" showServerInfo="false" />\n        <!-- SingleSignOn valve, share authentication between web applications'
 			]
 		]
 	],


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1211
Don't show server info in error response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apache Tomcat configuration handling to standardize log path references.
  * Enhanced error reporting capabilities in deployment configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->