### PR TITLE
Fix issue with global and site roles mixing up

### DIFF
--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/PermissionMappingsProviderImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/PermissionMappingsProviderImpl.java
@@ -87,20 +87,6 @@ public class PermissionMappingsProviderImpl implements PermissionMappingsProvide
 	private SitePermissionMappingsImpl fetchSitePermissionMappings(String site) throws ServiceLayerException {
 		SitePermissionMappingsImpl sitePermissionMappings = new SitePermissionMappingsImpl();
 
-		String globalRolesConfigPath = studioConfiguration.getProperty(CONFIGURATION_GLOBAL_CONFIG_BASE_PATH) +
-			FILE_SEPARATOR + studioConfiguration.getProperty(CONFIGURATION_GLOBAL_ROLE_MAPPINGS_FILE_NAME);
-		Document globalRoleMappingsDocument =
-			configurationService.getGlobalConfigurationAsDocument(globalRolesConfigPath);
-
-		String globalPermissionsConfigPath =
-			studioConfiguration.getProperty(CONFIGURATION_GLOBAL_CONFIG_BASE_PATH) + FILE_SEPARATOR +
-				studioConfiguration.getProperty(CONFIGURATION_GLOBAL_PERMISSION_MAPPINGS_FILE_NAME);
-		Document globalPermissionMappingsDocument =
-			configurationService.getGlobalConfigurationAsDocument(globalPermissionsConfigPath);
-
-		loadRoles(globalRoleMappingsDocument, sitePermissionMappings);
-		loadPermissions(globalPermissionMappingsDocument, sitePermissionMappings);
-
 		if (isNotEmpty(site) && !CS.equals(site, studioConfiguration.getProperty(CONFIGURATION_GLOBAL_SYSTEM_SITE))) {
 			Document roleMappingsDocument = configurationService.getConfigurationAsDocument(site, MODULE_STUDIO,
 				studioConfiguration.getProperty(CONFIGURATION_SITE_ROLE_MAPPINGS_FILE_NAME),
@@ -110,6 +96,20 @@ public class PermissionMappingsProviderImpl implements PermissionMappingsProvide
 				studioConfiguration.getProperty(CONFIGURATION_ENVIRONMENT_ACTIVE));
 			loadRoles(roleMappingsDocument, sitePermissionMappings);
 			loadPermissions(permissionsMappingsDocument, sitePermissionMappings);
+		} else {
+			String globalRolesConfigPath = studioConfiguration.getProperty(CONFIGURATION_GLOBAL_CONFIG_BASE_PATH) +
+					FILE_SEPARATOR + studioConfiguration.getProperty(CONFIGURATION_GLOBAL_ROLE_MAPPINGS_FILE_NAME);
+			Document globalRoleMappingsDocument = configurationService
+					.getGlobalConfigurationAsDocument(globalRolesConfigPath);
+
+			String globalPermissionsConfigPath = studioConfiguration.getProperty(CONFIGURATION_GLOBAL_CONFIG_BASE_PATH)
+					+ FILE_SEPARATOR +
+					studioConfiguration.getProperty(CONFIGURATION_GLOBAL_PERMISSION_MAPPINGS_FILE_NAME);
+			Document globalPermissionMappingsDocument = configurationService
+					.getGlobalConfigurationAsDocument(globalPermissionsConfigPath);
+
+			loadRoles(globalRoleMappingsDocument, sitePermissionMappings);
+			loadPermissions(globalPermissionMappingsDocument, sitePermissionMappings);
 		}
 		return sitePermissionMappings;
 	}


### PR DESCRIPTION
Fix issue with global and site roles mixing up
https://github.com/craftersoftware/craftercms/issues/8798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission mapping retrieval so site-specific configurations no longer load global role and permission mappings unnecessarily.
  * Ensured global roles and permissions are loaded correctly for the global/system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->