### PR TITLE
Gradle updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,11 @@ For more information on CrafterCMS Git Workflow, please review [CrafterCMS Git W
 ## 2.1 Commands
 
 * `download` Download dependencies
-* `clone` Clone CrafterCMS modules
 * `selfUpdate` Update the parent project (`craftercms`)
-* `update` Update modules
 * `clean` Clean modules
 * `build` Build modules
 * `deploy` Deploy modules
-* `upgrade` Upgrade modules (same as `update`, `clean`, `build`, `deploy`)
+* `upgrade` Upgrade modules (same as  `selfUpdate`, `clean`, `build`, `deploy`)
 * `start` Start CrafterCMS
 * `stop` Stop CrafterCMS
 * `status` Report status on running environments if any
@@ -82,18 +80,15 @@ For more information on CrafterCMS Git Workflow, please review [CrafterCMS Git W
 * `overwriteArtifact`: Update and overwrite the downloaded artifacts (example: OpenSearch, Tomcat, ...) that's cached in the downloads folder by downloading it again, default `false`
 * `gitRemote`: Git remote name to use in cloned modules, default `origin`
 * `gitBranch`: Git branch to use when cloning modules, default `develop` (for develop branch)
-* `gitUrl`: Which Git URL to use, default `https://github.com/craftercms/`
 * `socialRequired`: Include Social in the build, default `false`
 * `profileRequired`: Include Profile in the build, default `false`
 * `startSearch` or `withSearch`: start OpenSearch, default `true`
 * `startMongoDB`: start MongoDB, default `false` unless Profile or Social are enabled. This is automatic.
-* `unitTest`: Run unit tests during build, default `false`
-* `shallowClone`: Clone only the latest commits and not the entire history (faster, but you lose history), default `false`
 * `bundlesDir`: Where to deposit binaries, default `./bundles`
-* `downloadGrapes`: Download Grapes ahead of time (useful when no public Internet is available), default `false`
+* `downloadGrapes`: Download Grapes ahead of time (useful when no public Internet is available), default `true`
 * `downloadDir`: Where to store downloads, default `./downloads`
-* `authoringEnvDir`: Where to store the authoring environment, default `./craftercms/crafter-authoring`
-* `deliveryEnvDir`: Where to store the delivery environment, default `./craftercms/crafter-delivery`
+* `authoringEnvDir`: Where to store the authoring environment, default `./crafter-authoring`
+* `deliveryEnvDir`: Where to store the delivery environment, default `./crafter-delivery`
 * `currentPlatform`: What platform to build to (`linux` or `darwin`), default is the build machine's OS
 * `currentArch`: What arch to build to (`aarch64` or `x86_64`), default is the build machine's arch
 * `pushDockerImages`: Push the Docker images to DockerHub (if you have the right permissions), default `false`
@@ -224,7 +219,7 @@ CrafterCMS comprises the following modules:
 * [`social`](https://craftercms.com/docs/current/reference/modules/social/index.html)
 * [`deployer`](https://craftercms.com/docs/current/reference/modules/deployer/index.html)
 
-You'll find these projects checked out and ready for you to contribute to in the folder `craftercms/src/{modules}`.
+You'll find these projects under the root project directory and ready for you to contribute to in the folder `{Project Root}/{module}`.
 
 ### 4.3.1. Forking a Module
 
@@ -237,19 +232,16 @@ You can now work in your local system, and build/deploy and ultimately push to y
 To update your project with the latest:
 
 ```bash
-    ./gradlew update
+    ./gradlew selfUpdate
 ```
 
-### 4.3.2. Update, Build, Deploy, Start, and Stop a Module
+### 4.3.2. Build, Deploy a Module
 
-You can update, build, deploy, start or stop a module by:
+You can build or deploy a module by:
 
 ```bash
-    ./gradlew update -Pmodules=studio
-    ./gradlew build -Pmodules=studio
-    ./gradlew deploy -Pmodules=studio -Penv=authoring
-    ./gradlew start -Pmodules=studio -Penv=authoring
-    ./gradlew stop -Pmodules=studio -Penv=authoring
+    ./gradlew studio:build
+    ./gradlew studio:deploy -Penv=authoring
 ```
 
 > **_NOTE:_**
@@ -326,28 +318,34 @@ For more information about Apache Tomcat, and OpenSearch please refer to the fol
 As we have seen in the getting started section above, to run a gradle task, we run the following from the root of the project:
 
 ```bash
-   ./gradlew command [-Penv={env}] [-Pmodules={module}]
+   ./gradlew command [-Penv={env}]
+```
+```bash
+   ./gradlew module:task [-Penv={env}]
+```
+e.g.:
+```bash
+   ./gradlew engine:deploy -Penv=authoring
 ```
 
 Here's a list of commands (Gradle tasks) available:
 
-| Command<br>``command`` | Description                                                                                    | Env Options<br>``env``  | Module Options<br>``module``                                                                                                                                                                                                                                                    |
+| Command<br>``command`` | Description                                                                                    | Env Options<br>``env``  | Applies to modules                                                                                                                                                                                                                                                    |
 |------------------------|------------------------------------------------------------------------------------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| clone                  | Clones CrafterCMS                                                                              | <ul><li>None</li></ul>  | <ul><li>None</li></ul>                                                                                                                                                                                                                                                          |
-| build                  | Build module/s or an entire environment<br>`Note:: build will clone if needed`                 | authoring<hr> delivery  | <ul><li>None</li><li>studio</li><li>deployer</li><li>engine</li><li>search</li><li>social</li><li>profile</li><li>core</li><li>commons</li><li>studio-ui</li><li>groovy-sandbox</li><li>script-security-plugin</li><li>cli</li></ul>                                            |
-| deploy                 | Deploy module/s or an entire environment                                                       | authoring<hr>delivery   | <ul><li>None</li><li>studio</li><li>deployer</li><li>engine</li><li>search</li><li>social</li><li>social-admin</li><li>profile</li><li>profile-admin</li><li>commons</li><li>core</li><li>studio-ui</li><li>groovy-sandbox</li><li>script-security-plugin</li><li>cli</li></ul> |
-| bundle                 | Build deployable and distributable binaries                                                    | authoring <hr> delivery | <ul><li>None</li></ul>                                                                                                                                                                                                                                                          |
-| start                  | Start CrafterCMS                                                                               | authoring <hr> delivery | <ul><li>None</li></ul>                                                                                                                                                                                                                                                          |
-| stop                   | Stop CrafterCMS                                                                                | authoring <hr> delivery | <ul><li>None</li></ul>                                                                                                                                                                                                                                                          |
-| update                 | Update a module or modules                                                                     | <ul><li>None</li></ul>  | <ul><li>None</li><li>studio</li><li>deployer</li><li>engine</li><li>search</li><li>social</li><li>profile</li><li>core</li><li>commons</li><li>studio-ui</li><li>groovy-sandbox</li><li>script-security-plugin</li><li>cli</li></ul>                                            |
-| upgrade                | Upgrades the installed Tomcat version, etc, without deleting your data then builds and deploys | <ul><li>None</li></ul>  | <ul><li>None</li></ul>                                                                                                                                                                                                                                                          |
-| selfupdate             | Updates the CrafterCMS project (gradle)                                                        | <ul><li>None</li></ul>  | <ul><li>None</li></ul>                                                                                                                                                                                                                                                          |
-| clean                  | Delete all compiled objects                                                                    | <ul><li>None</li></ul>  | <ul><li>None</li></ul>                                                                                                                                                                                                                                                          |
+| build                  | Build all modules<br>                 | None  | Yes                                            |
+| deploy                 | Deploy module/s or an entire environment                                                       | authoring<hr>delivery   | Yes |
+| bundle                 | Build deployable and distributable binaries                                                    | authoring <hr> delivery | No                                                                                                                                                                                                                                                          |
+| start                  | Start CrafterCMS                                                                               | authoring <hr> delivery | No                                                                                                                                                                                                                                                          |
+| stop                   | Stop CrafterCMS                                                                                | authoring <hr> delivery | No                                                                                                                                                                                                                                                          |
+| upgrade                | Upgrades the installed Tomcat version, etc., without deleting your data then builds and deploys | None  | No                                                                                                                                                                                                                                                          |
+| selfUpdate             | Updates the CrafterCMS project (gradle)                                                        | None  | No                                                                                                                                                                                                                                                          |
+| clean                  | Delete all compiled objects                                                                    | None  |  Yes                                                                                                                                                                                                                                                          |
 
 > **_NOTE:_**
 * If you don't specify the ``env`` parameter, it means all environments (where applicable).
 * In the current version of CrafterCMS, some services run in the same Web container, and that implies the stopping/starting of one of these services will cause other services to stop/start as well.
-* The Gradle task property ``modules`` accepts one or multiple module/s, separated by commas like this: ``./gradlew build -Pmodules=search,studio``
+* List the modules and the tasks to build multiple modules in the same command: ``./gradlew engine:build studio:build``
+* Use `-p module` to run multiple tasks for a module: ``./gradlew -p studio clean build deploy -Penv=authoring``
 * The ``clean`` command does not delete previously built environment folders ``crafter-authoring`` and ``crafter-delivery``. To build a fresh copy of these two, backup your custom data and delete both folders manually.
 
 <br><br>
@@ -372,7 +370,7 @@ The Gradle task above will:
 To build a module (all module options for task ``build`` are listed in the table above), run the following (we'll build the module *studio* in the example below):
 
 ```bash
-   ./gradlew build -Pmodules=studio
+   ./gradlew studio:build
 ```
 
 To build an environment, run the following (we'll build the authoring environment in the example below:

--- a/build.gradle
+++ b/build.gradle
@@ -93,43 +93,6 @@ task selfUpdate() {
 	}
 }
 
-clean() {
-	description = 'Cleans the modules.'
-	dependsOn = ["preFlightCheck"]
-	doFirst {
-		getBuildModules().each { module ->
-			println "Cleaning $module"
-
-			cleanModule(module)
-		}
-	}
-}
-
-build() {
-	description = 'Builds the modules and prepares the binaries for deployment.'
-	mustRunAfter clean
-	dependsOn = ["preFlightCheck"]
-	doFirst {
-		getBuildModules().each { module ->
-			println "Building $module"
-
-			buildModule(module, unitTest)
-		}
-	}
-}
-
-task deployToMaven() {
-	description = 'Builds and publishes modules to the local Maven repository (publishToMavenLocal).'
-	dependsOn = ["preFlightCheck"]
-	doFirst {
-		getDeployToMavenModules().each { module ->
-			println "Deploying $module"
-
-			deployModule(module, unitTest)
-		}
-	}
-}
-
 task buildBaseEnvs() {
 	description = 'Build base target environments.'
 	dependsOn = ["download"]
@@ -158,15 +121,12 @@ task buildBom() {
 }
 
 task deploy() {
-	description = 'Deploys the module artifacts prepares the authoring/delivery environments.'
+	group = 'deployment'
+	description = 'Deploys module artifacts and prepares the authoring/delivery environments. ' +
+		'Use :<module>:deploy (e.g. :studio:deploy -Penv=authoring) to deploy a single module.'
 	mustRunAfter build
 	dependsOn = ["buildBaseEnvs"]
-	doFirst {
-		getEnvironments().each { environment ->
-			println "Deploying $environment"
-			deployEnvironment(environment, getDeployModules(), overwriteChangedFiles, profileRequired, socialRequired)
-		}
-	}
+	// Module deploy tasks are attached in deploy.gradle (projectsEvaluated).
 }
 
 task upgrade() {

--- a/commons.gradle
+++ b/commons.gradle
@@ -56,7 +56,7 @@ ext.execCommand = { command, dir ->
 		}
 	}
 
-	//System.out.println("Executing command \"" + dir + ":" + cmd + "\"")
+	// System.out.println("Executing command \"" + dir + ":" + cmd + "\"")
 
 	def proc = cmd.execute(null, file(dir))
 
@@ -149,15 +149,13 @@ ext.gradleModules = [
 	'cli': ':cli'
 ]
 
-ext.runGradleModuleTask = { module, task, unitTest, extraArgs = [] ->
+// This is used to run external tasks: bomGenerate, publishMavenPublicationToGitHubPackagesRepository
+ext.runGradleModuleTask = { module, task, extraArgs = [] ->
 	def projects = gradleModules[module]
 	if (projects == null) {
 		return false
 	}
-	def gradleArgs = ["./gradlew", "-q"]
-	if (!unitTest) {
-		gradleArgs += ["-x", "test"]
-	}
+	def gradleArgs = ["./gradlew"]
 	if (extraArgs) {
 		gradleArgs.addAll(extraArgs as List)
 	}
@@ -170,31 +168,8 @@ ext.runGradleModuleTask = { module, task, unitTest, extraArgs = [] ->
 	return true
 }
 
-ext.cleanModule = { module ->
-	if (!runGradleModuleTask(module, 'clean', true)) {
-		throw new GradleException("No Gradle module mapping for $module")
-	}
-}
-
-ext.buildModule = { module, unitTest ->
-	if (!runGradleModuleTask(module, 'build', unitTest)) {
-		throw new GradleException("No Gradle module mapping for $module")
-	}
-}
-
-ext.deployModule = { module, unitTest ->
-	if (module == "craftercms") {
-		println "Skipping craftercms parent POM deploy (dependency management is in gradle/libs.versions.toml)"
-		return
-	}
-
-	if (!runGradleModuleTask(module, 'publishToMavenLocal', unitTest)) {
-		throw new GradleException("No Gradle module mapping for $module")
-	}
-}
-
 ext.buildBom = { module ->
-	if (runGradleModuleTask(module, 'bomGenerate', false)) {
+	if (runGradleModuleTask(module, 'bomGenerate')) {
 		return
 	}
 

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -9,8 +9,9 @@ ext.commonDeployArtifacts = [
 	],
 	[
 		module: 'engine',
-		from  : "${projectDir}/engine/build/libs/ROOT.war",
-		into  : "/bin/apache-tomcat/webapps/"
+		from  : "${projectDir}/engine/build/libs/crafter-engine.war",
+		into  : "/bin/apache-tomcat/webapps/ROOT.war",
+		copyFile: true
 	],
 	[
 		module: 'profile',
@@ -42,8 +43,9 @@ ext.commonDeployArtifacts = [
 ext.authoringDeployArtifacts = [
 	[
 		module: 'studio',
-		from  : "${projectDir}/studio/build/libs/studio.war",
-		into  : "/bin/apache-tomcat/webapps/"
+		from  : "${projectDir}/studio/build/libs/crafter-studio.war",
+		into  : "/bin/apache-tomcat/webapps/studio.war",
+		copyFile: true,
 	]
 ]
 
@@ -93,7 +95,11 @@ ext.deployBaseEnvironment = { envFolder, modules, overwriteChangedFiles, profile
 		}
 
 		if (performSync) {
-			syncFolder("${projectDir}", from, envFolder + into, exclude, overwriteChangedFiles, true)
+			if (item.copyFile) {
+				copyFile("${projectDir}", from, envFolder + into)
+			} else {
+				syncFolder("${projectDir}", from, envFolder + into, exclude, overwriteChangedFiles, true)
+			}
 		}
 	}
 
@@ -130,7 +136,11 @@ ext.deployAuthoringEnvironment = { modules, overwriteChangedFiles, profileRequir
 		}
 
 		if (performSync) {
-			syncFolder("${projectDir}", from, "${authoringEnvDir}" + into, exclude, overwriteChangedFiles, true)
+			if(item.copyFile) {
+				copyFile("${projectDir}", from, "${authoringEnvDir}" + into)
+			} else {
+				syncFolder("${projectDir}", from, "${authoringEnvDir}" + into, exclude, overwriteChangedFiles, true)
+			}
 		}
 	}
 
@@ -162,7 +172,11 @@ ext.deployDeliveryEnvironment = { modules, overwriteChangedFiles, profileRequire
 		}
 
 		if (performSync) {
-			syncFolder("${projectDir}", from, "${deliveryEnvDir}" + into, exclude, overwriteChangedFiles, true)
+			if (item.copyFile) {
+				copyFile("${projectDir}", from, "${deliveryEnvDir}" + into)
+			} else {
+				syncFolder("${projectDir}", from, "${deliveryEnvDir}" + into, exclude, overwriteChangedFiles, true)
+			}
 		}
 	}
 
@@ -186,5 +200,57 @@ ext.deployEnvironment = { environment, modules, overwriteChangedFiles, profileRe
 	} else {
 		logger.error("Unknown environment \"" + environment + "\"")
 		throw new GradleException("Unknown environment \"" + environment + "\"")
+	}
+}
+
+// Gradle project path -> deploy artifact module name (as used in *DeployArtifacts)
+ext.deployModuleProjects = [
+	'deployer'                : 'deployer',
+	'engine'                  : 'engine',
+	'profile:server'          : 'profile',
+	'profile:admin-console'   : 'profile-admin',
+	'social:server'           : 'social',
+	'social:admin'            : 'social-admin',
+	'cli'                     : 'cli',
+	'studio'                  : 'studio'
+]
+
+gradle.projectsEvaluated {
+	def profileRequired = getExplicitlyRequestedModules().contains('profile') || rootProject.profileRequired
+	def socialRequired = getExplicitlyRequestedModules().contains('social') || rootProject.socialRequired
+
+	deployModuleProjects.each { projectPath, moduleName ->
+		def proj = rootProject.findProject(":${projectPath}")
+		if (proj == null) {
+			return
+		}
+		// Register a deploy task for each project
+		proj.tasks.register('deploy') {
+			group = 'deployment'
+			description = "Deploys ${moduleName} artifact(s) to the selected environment(s) (-Penv=authoring|delivery)"
+			dependsOn rootProject.tasks.named('buildBaseEnvs'), proj.tasks.named('build')
+			doLast {
+				rootProject.getEnvironments().each { environment ->
+					println "Deploying ${moduleName} to ${environment}"
+					rootProject.deployEnvironment(
+						environment,
+						[moduleName],
+						rootProject.overwriteChangedFiles,
+						profileRequired,
+						socialRequired
+					)
+				}
+			}
+		}
+	}
+
+	def allowedModules = (rootProject.getDeployModules() as List).toSet()
+	def moduleDeployTasks = deployModuleProjects
+		.findAll { path, name -> allowedModules.contains(name) }
+		.collect { path, name -> rootProject.project(path).tasks.named('deploy') }
+
+	// Make the root deploy task depend on all module deploy tasks
+	rootProject.tasks.named('deploy').configure {
+		dependsOn moduleDeployTasks
 	}
 }

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -24,7 +24,7 @@ apply from: "${rootDir}/gradle/java-library.gradle"
 apply from: "${rootDir}/gradle/war.gradle"
 
 base {
-	archivesName = 'ROOT'
+	archivesName = 'crafter-engine'
 }
 
 dependencies {
@@ -118,7 +118,7 @@ dependencies {
 }
 
 war {
-	archiveFileName = 'ROOT.war'
+	archiveFileName = 'crafter-engine.war'
 }
 
 configureFilteredWarResource(

--- a/global-settings.gradle
+++ b/global-settings.gradle
@@ -86,7 +86,6 @@ project.ext.set("socialRequired", getPropertySafelyWithDefaults("crafter.social"
 project.ext.set("profileRequired", (getPropertySafelyWithDefaults("crafter.profile", "false").toBoolean()
 	|| (getPropertySafelyWithDefaults("profileRequired", "false").toBoolean()
 	|| socialRequired)))
-project.ext.set("unitTest", getPropertySafelyWithDefaults("unitTest", "false").toBoolean())
 project.ext.set("startMongoDB", getPropertySafelyWithDefaults("startMongodb", (profileRequired || socialRequired)).toBoolean())
 project.ext.set("startSearch", getPropertySafelyWithDefaults("startSearch", getPropertySafelyWithDefaults("withSearch", "true")).toBoolean())
 project.ext.set("startCommand", project.hasProperty("debug") ? "debug" : "start")

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,6 @@ deliverySearchPort=9202
 deliveryMongoDbPort=28020
 deliverySmtpPort=25
 gitRemote=origin
-unitTest=false
 overwriteChangedFiles=true
 commandTimeout=1000000
 downloadDir=./downloads
@@ -62,7 +61,6 @@ deliveryEnvDir=./crafter-delivery
 bundlesDir=./bundles
 startMongodb=false
 withSearch=true
-quietBuild=true
 # Docker
 authoringTomcatImageName=craftercms/authoring_tomcat
 authoringLocalImageName=craftercms/authoring_local

--- a/modules.gradle
+++ b/modules.gradle
@@ -27,68 +27,78 @@ ext.deployToMavenModules = ["groovy-sandbox", "script-security-plugin", "commons
 			    "core", "search", "profile", "engine", "deployer", "studio",
 			    "social", "cli"]
 
+// Modules named on the command line (e.g. engine:build, :studio:deploy).
+ext.getExplicitlyRequestedModules = { ->
+	def modules = []
+	gradle.startParameter.taskNames.each { taskName ->
+		def name = taskName.startsWith(':') ? taskName.substring(1) : taskName
+		// Unqualified tasks (build, deploy) are not module-scoped
+		if (!name.contains(':')) {
+			return
+		}
+		def projectPath = name.substring(0, name.lastIndexOf(':'))
+		def topLevel = projectPath.contains(':')
+			? projectPath.substring(0, projectPath.indexOf(':'))
+			: projectPath
+		if (allModules.contains(topLevel) && !modules.contains(topLevel)) {
+			modules << topLevel
+		}
+	}
+	return modules
+}
+
 ext.getAllModules = { ->
-	String[] result
-
-	if (project.hasProperty("modules"))
-		result = project.property("modules").toLowerCase().split(",")
-	else
-		result = allModules
-
-	return result
+	def result = getExplicitlyRequestedModules()
+	if (result != null && result.size() > 0) {
+		return result
+	}
+	return allModules
 }
 
 ext.getBuildModules = { ->
-	String[] result
-
-	if (project.hasProperty("modules"))
-		result = project.property("modules").toLowerCase().split(",")
-	else
-		result = buildModules
-
-	return result
+	def result = getExplicitlyRequestedModules()
+	if (result != null && result.size() > 0) {
+		return result
+	}
+	return buildModules
 }
 
 ext.getDeployModules = { ->
-	String[] result
-
-	if (project.hasProperty("modules"))
-		result = project.property("modules").toLowerCase().split(",")
-	else
-		result = deployModules
-
-	return result
+	def result = getExplicitlyRequestedModules()
+	if (result != null && result.size() > 0) {
+		return result
+	}
+	return deployModules
 }
 
 ext.getDeployToMavenModules = { ->
-	String[] result
-
-	if (project.hasProperty("modules"))
-		result = project.property("modules").toLowerCase().split(",")
-	else
-		result = deployToMavenModules
-
-	return result
+	def result = getExplicitlyRequestedModules()
+	if (result != null && result.size() > 0) {
+		return result
+	}
+	return deployToMavenModules
 }
 
-// When -Pmodules is set and root orchestration tasks run, Gradle would otherwise also execute
-// clean/build on every subproject (LifecycleBasePlugin). Disable all subproject tasks so only
-// getBuildModules() subprocess invocations run; direct :project:task requests are unaffected.
+// Skip tests unless explicitly requested (e.g. ./gradlew test or :studio:test).
+// Only the requested projects' Test tasks stay enabled — so
+// `./gradlew studio:test engine:build` runs studio tests but not engine's.
 gradle.taskGraph.whenReady { graph ->
-	if (!project.hasProperty('modules')) {
+	def taskNames = gradle.startParameter.taskNames
+	// Unqualified `test` selects every project's test via task name matching.
+	if (taskNames.any { it == 'test' }) {
 		return
 	}
 
-	def orchestratedRootTasks = ['clean', 'build', 'deployToMaven', 'buildBom']
-	def runningRootOrchestration = graph.allTasks.any { task ->
-		task.project == rootProject && orchestratedRootTasks.contains(task.name)
-	}
-	if (!runningRootOrchestration) {
-		return
-	}
+	def requestedTestProjects = taskNames.findAll { it == ':test' || it.endsWith(':test') }
+		.collect { name ->
+			if (name == ':test') {
+				return rootProject.path
+			}
+			return name.substring(0, name.length() - ':test'.length())
+		}.toSet()
 
-	graph.allTasks.each { task ->
-		if (task.project != rootProject) {
+	graph.allTasks.findAll { it instanceof Test }.each { task ->
+		if (!requestedTestProjects.contains(task.project.path)) {
 			task.enabled = false
 		}
 	}

--- a/release.gradle
+++ b/release.gradle
@@ -191,7 +191,7 @@ tasks.register('releasePublishMaven') {
 					publishArgs << "-P${prop}=${value}"
 				}
 			}
-			if (!runGradleModuleTask(module, 'publishMavenPublicationToGitHubPackagesRepository', false, publishArgs)) {
+			if (!runGradleModuleTask(module, 'publishMavenPublicationToGitHubPackagesRepository', publishArgs)) {
 				throw new GradleException("No Gradle module mapping for $module")
 			}
 		}

--- a/settings.gradle
+++ b/settings.gradle
@@ -78,7 +78,8 @@ include 'profile:client'
 include 'profile:security-provider'
 include 'profile:server'
 include 'profile:admin-console'
-include 'profile:integration-tests'
+// TODO: fix or remove this
+// include 'profile:integration-tests'
 
 include 'engine'
 

--- a/studio/build.gradle
+++ b/studio/build.gradle
@@ -24,7 +24,7 @@ apply from: "${rootDir}/gradle/java-library.gradle"
 apply from: "${rootDir}/gradle/war.gradle"
 
 base {
-	archivesName = 'studio'
+	archivesName = 'crafter-studio'
 }
 
 def studioUiDir = project(':studio-ui').projectDir
@@ -157,7 +157,7 @@ dependencies {
 }
 
 war {
-	archiveFileName = 'studio.war'
+	archiveFileName = 'crafter-studio.war'
 	dependsOn ':engine:war', ':studio-ui:build'
 	exclude '**/crafterTemplateRepository/**'
 

--- a/studio/src/main/java/org/craftercms/studio/config/WebsocketConfig.java
+++ b/studio/src/main/java/org/craftercms/studio/config/WebsocketConfig.java
@@ -79,7 +79,7 @@ public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
 	 * CSRF interceptor for WebSocket messages
 	 * This needs to be declared so the {@link org.springframework.security.config.websocket.WebSocketMessageBrokerSecurityBeanDefinitionParser} picks it up
 	 *
-	 * @see <a href="https://github.com/spring-projects/spring-security/issues/17260"><websocket-message-broker> should use XorCsrfChannelInterceptor by default</a>
+	 * @see <a href="https://github.com/spring-projects/spring-security/issues/17260">&lt;websocket-message-broker&gt; should use XorCsrfChannelInterceptor by default</a>
 	 */
 	@Bean
 	public CsrfChannelInterceptor csrfChannelInterceptor() {


### PR DESCRIPTION
Gradle updates
https://github.com/craftersoftware/craftercms-e/issues/1262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Testing**
  * Removed `unitTest` and `quietBuild` Gradle options.
  * Test tasks run only when `test` is explicitly requested; otherwise non-requested tests are disabled.

* **Deployment**
  * Added module-scoped `deploy` task wiring and module selection.
  * WAR deployment now supports direct file copy for configured artifacts.
  * Root `deploy` now relies on module `deploy` tasks.

* **Artifact Naming**
  * Renamed WAR outputs to `crafter-engine.war` and `crafter-studio.war`.

* **Documentation**
  * Refreshed Gradle commands/options to remove outdated `clone/update/modules` and `unitTest` references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->