### PR TITLE
[1005E]

### DIFF
--- a/studio-ui/ui/app/src/components/AccountManagement/AccountManagement.tsx
+++ b/studio-ui/ui/app/src/components/AccountManagement/AccountManagement.tsx
@@ -59,6 +59,7 @@ import {
 	setStoredEnableAnimations,
 	setStoredSnackbarDuration
 } from '../../utils/state';
+import { USER_PASSWORD_MAX_LENGTH } from '../UserManagement/utils';
 
 const decrementButtonSx: BoxProps['sx'] = {
 	borderTopRightRadius: 0,
@@ -279,6 +280,9 @@ export function AccountManagement(props: AccountManagementProps) {
 							onChange={(e) => {
 								setCurrentPassword(e.target.value);
 							}}
+							slotProps={{
+								htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH }
+							}}
 						/>
 						<PasswordTextField
 							margin="normal"
@@ -298,7 +302,9 @@ export function AccountManagement(props: AccountManagementProps) {
 							}
 							onFocus={(e) => setAnchorEl(e.target)}
 							onBlur={() => setAnchorEl(null)}
-							inputProps={{ autoComplete: 'new-password' }}
+							slotProps={{
+								htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH, autoComplete: 'new-password' }
+							}}
 						/>
 						<PasswordTextField
 							margin="normal"
@@ -318,6 +324,9 @@ export function AccountManagement(props: AccountManagementProps) {
 									/>
 								)
 							}
+							slotProps={{
+								htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH }
+							}}
 						/>
 						<PrimaryButton
 							disabled={!validPassword || newPassword !== verifiedPassword || currentPassword === ''}

--- a/studio-ui/ui/app/src/components/AccountManagement/AccountManagement.tsx
+++ b/studio-ui/ui/app/src/components/AccountManagement/AccountManagement.tsx
@@ -281,7 +281,7 @@ export function AccountManagement(props: AccountManagementProps) {
 								setCurrentPassword(e.target.value);
 							}}
 							slotProps={{
-								htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH }
+								htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH, autoComplete: 'current-password' }
 							}}
 						/>
 						<PasswordTextField
@@ -325,7 +325,7 @@ export function AccountManagement(props: AccountManagementProps) {
 								)
 							}
 							slotProps={{
-								htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH }
+								htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH, autoComplete: 'new-password' }
 							}}
 						/>
 						<PrimaryButton

--- a/studio-ui/ui/app/src/components/LoginView/LoginView.tsx
+++ b/studio-ui/ui/app/src/components/LoginView/LoginView.tsx
@@ -46,7 +46,7 @@ import Menu from '@mui/material/Menu';
 import { useMount } from '../../hooks/useMount';
 import { useDebouncedInput } from '../../hooks/useDebouncedInput';
 import { PasswordStrengthDisplayPopper } from '../PasswordStrengthDisplayPopper';
-import { USER_USERNAME_MAX_LENGTH } from '../UserManagement/utils';
+import { USER_PASSWORD_MAX_LENGTH, USER_USERNAME_MAX_LENGTH } from '../UserManagement/utils';
 import useTimer from '../../hooks/useTimer';
 import { nnou } from '../../utils/object';
 import moment from 'moment-timezone';
@@ -400,7 +400,9 @@ function ResetView(props: SubViewProps) {
 					placeholder={formatMessage(translations.resetPasswordFieldPlaceholderLabel)}
 					onFocus={(e) => setAnchorEl(e.target)}
 					onBlur={() => setAnchorEl(null)}
-					inputProps={{ autoComplete: 'new-password' }}
+					slotProps={{
+						htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH, autoComplete: 'new-password' }
+					}}
 				/>
 				<PasswordTextField
 					id="resetFormPasswordConfirmField"
@@ -414,6 +416,9 @@ function ResetView(props: SubViewProps) {
 					className={classes?.resetPassword}
 					sxs={{ root: { mb: 0 } }}
 					placeholder={formatMessage(translations.resetPasswordConfirmFieldPlaceholderLabel)}
+					slotProps={{
+						htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH, autoComplete: 'new-password' }
+					}}
 				/>
 				{children}
 			</DialogContent>

--- a/studio-ui/ui/app/src/components/PasswordTextField/PasswordTextField.tsx
+++ b/studio-ui/ui/app/src/components/PasswordTextField/PasswordTextField.tsx
@@ -37,7 +37,7 @@ const translations = defineMessages({
 });
 
 const PasswordTextField = React.forwardRef<HTMLDivElement, PasswordTextFieldProps>((props, ref) => {
-	const { visibilitySwitch = true, initialVisible = false, sxs } = props;
+	const { visibilitySwitch = true, initialVisible = false, sxs, slotProps, InputProps, ...textFieldProps } = props;
 	const { formatMessage } = useIntl();
 	const [showPassword, setShowPassword] = useState(initialVisible);
 	const inputRef = useRef<HTMLInputElement>(undefined);
@@ -50,33 +50,41 @@ const PasswordTextField = React.forwardRef<HTMLDivElement, PasswordTextFieldProp
 		}, 0);
 	};
 
+	const visibilityAdornment = (
+		<InputAdornment position="end">
+			<IconButton
+				edge="end"
+				aria-label={formatMessage(translations.toggleVisibilityButtonText)}
+				onClick={handleClickShowPassword}
+				size="large"
+			>
+				{showPassword ? <VisibilityOff /> : <Visibility />}
+			</IconButton>
+		</InputAdornment>
+	);
+
 	return (
 		<TextField
-			{...props}
+			{...textFieldProps}
 			sx={sxs?.root}
 			ref={ref}
 			type={showPassword ? 'text' : 'password'}
 			slotProps={{
+				...slotProps,
 				htmlInput: {
+					...slotProps?.htmlInput,
 					ref: inputRef
 				},
 				input: visibilitySwitch
 					? {
-							...props.InputProps,
-							endAdornment: (
-								<InputAdornment position="end">
-									<IconButton
-										edge="end"
-										aria-label={formatMessage(translations.toggleVisibilityButtonText)}
-										onClick={handleClickShowPassword}
-										size="large"
-									>
-										{showPassword ? <VisibilityOff /> : <Visibility />}
-									</IconButton>
-								</InputAdornment>
-							)
+							...slotProps?.input,
+							...InputProps,
+							endAdornment: visibilityAdornment
 						}
-					: props.InputProps
+					: {
+							...slotProps?.input,
+							...InputProps
+						}
 			}}
 		/>
 	);

--- a/studio-ui/ui/app/src/components/ResetPasswordDialog/ResetPasswordDialog.tsx
+++ b/studio-ui/ui/app/src/components/ResetPasswordDialog/ResetPasswordDialog.tsx
@@ -30,6 +30,7 @@ import { showSystemNotification } from '../../state/actions/system';
 import PasswordTextField from '../PasswordTextField/PasswordTextField';
 import { PasswordStrengthDisplayPopper } from '../PasswordStrengthDisplayPopper';
 import { pushErrorDialog } from '../../utils/system';
+import { USER_PASSWORD_MAX_LENGTH } from '../UserManagement/utils';
 
 interface ResetPasswordDialogProps {
 	open: boolean;
@@ -109,7 +110,9 @@ function ResetPasswordDialogUI(props: ResetPasswordDialogProps) {
 					}}
 					onFocus={(e) => setAnchorEl(e.target)}
 					onBlur={() => setAnchorEl(null)}
-					inputProps={{ autoComplete: 'new-password' }}
+					slotProps={{
+						htmlInput: { maxLength: USER_PASSWORD_MAX_LENGTH, autoComplete: 'new-password' }
+					}}
 				/>
 				<PasswordStrengthDisplayPopper
 					open={Boolean(anchorEl)}


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms-e/issues/1005
https://github.com/craftersoftware/craftercms-e/issues/1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password fields now consistently enforce the maximum allowed password length across account management, login, and password reset flows.
  * Autocomplete is now applied correctly per field purpose (`current-password` vs `new-password`) during login and password reset.
  * Password visibility toggle behavior and the underlying input configuration are now more consistent across all password entry screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->