### PR TITLE
[1227E]

### DIFF
--- a/studio-ui/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/studio-ui/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -118,6 +118,7 @@ export interface PathNavigatorStateProps {
 	isRootPathMissing: boolean;
 	sortStrategy: GetChildrenOptions['sortStrategy'];
 	order: GetChildrenOptions['order'];
+	revertPath?: string;
 }
 
 // @see https://github.com/craftercms/craftercms/issues/5360

--- a/studio-ui/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/studio-ui/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -119,6 +119,7 @@ export interface PathNavigatorStateProps {
 	sortStrategy: GetChildrenOptions['sortStrategy'];
 	order: GetChildrenOptions['order'];
 	revertPath?: string;
+	pathFetchRequestId?: number;
 }
 
 // @see https://github.com/craftercms/craftercms/issues/5360

--- a/studio-ui/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/studio-ui/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -118,7 +118,7 @@ export interface PathNavigatorStateProps {
 	isRootPathMissing: boolean;
 	sortStrategy: GetChildrenOptions['sortStrategy'];
 	order: GetChildrenOptions['order'];
-	revertPath?: string;
+	revertPathByRequestId?: Record<number, string>;
 	pathFetchRequestId?: number;
 }
 

--- a/studio-ui/ui/app/src/components/PathNavigator/PathNavigator.tsx
+++ b/studio-ui/ui/app/src/components/PathNavigator/PathNavigator.tsx
@@ -118,7 +118,8 @@ export interface PathNavigatorStateProps {
 	isRootPathMissing: boolean;
 	sortStrategy: GetChildrenOptions['sortStrategy'];
 	order: GetChildrenOptions['order'];
-	revertPathByRequestId?: Record<number, string>;
+	/** Last `currentPath` confirmed by an applied fetch result; a failed fetch reverts to it. */
+	lastConfirmedPath?: string;
 	pathFetchRequestId?: number;
 }
 

--- a/studio-ui/ui/app/src/state/actions/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/actions/pathNavigator.ts
@@ -96,7 +96,7 @@ export const pathNavigatorFetchPath =
 
 export const pathNavigatorFetchPathComplete =
 	/*#__PURE__*/ createAction<
-		PayloadWithId<{ parent?: ContentItem; children: GetChildrenResponse; pathFetchRequestId?: number }>
+		PayloadWithId<{ parent?: ContentItem; children: GetChildrenResponse; pathFetchRequestId: number }>
 	>('PATH_NAV_FETCH_PATH_COMPLETE');
 
 export const pathNavigatorBulkFetchPathComplete = /*#__PURE__*/ createAction<{
@@ -110,7 +110,7 @@ export const pathNavigatorFetchParentItemsComplete = /*#__PURE__*/ createAction<
 export const pathNavigatorFetchPathFailed = /*#__PURE__*/ createAction<{
 	id: string;
 	error: Omit<AjaxError, 'request' | 'xhr'>;
-	pathFetchRequestId?: number;
+	pathFetchRequestId: number;
 }>('PATH_NAV_FETCH_PATH_FAILED');
 
 export const pathNavigatorBulkFetchPathFailed = /*#__PURE__*/ createAction<{

--- a/studio-ui/ui/app/src/state/actions/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/actions/pathNavigator.ts
@@ -51,11 +51,16 @@ export const pathNavigatorSetCurrentPath =
 	/*#__PURE__*/ createAction<PayloadWithId<{ path: string }>>('PATH_NAV_SET_CURRENT_PATH');
 
 export const pathNavigatorConditionallySetPath = /*#__PURE__*/ createAction<
-	PayloadWithId<{ path: string; keyword?: string }>
+	PayloadWithId<{ path: string; keyword?: string; pathFetchRequestId?: number }>
 >('PATH_NAV_CONDITIONALLY_SET_PATH');
 
 export const pathNavigatorConditionallySetPathComplete = /*#__PURE__*/ createAction<
-	PayloadWithId<{ path: string; parent?: ContentItem; children: GetChildrenResponse }>
+	PayloadWithId<{
+		path: string;
+		parent?: ContentItem;
+		children: GetChildrenResponse;
+		pathFetchRequestId?: number;
+	}>
 >('PATH_NAV_CONDITIONALLY_SET_PATH_COMPLETE');
 
 export const pathNavigatorConditionallySetPathFailed = /*#__PURE__*/ createAction<{

--- a/studio-ui/ui/app/src/state/actions/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/actions/pathNavigator.ts
@@ -66,6 +66,7 @@ export const pathNavigatorConditionallySetPathComplete = /*#__PURE__*/ createAct
 export const pathNavigatorConditionallySetPathFailed = /*#__PURE__*/ createAction<{
 	id: string;
 	error: { status: number; message: string };
+	pathFetchRequestId?: number;
 }>('PATH_NAV_CONDITIONALLY_SET_PATH_FAILED');
 
 export const pathNavigatorRefresh = /*#__PURE__*/ createAction<{ id: string }>('PATH_NAV_REFRESH');

--- a/studio-ui/ui/app/src/state/actions/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/actions/pathNavigator.ts
@@ -109,7 +109,7 @@ export const pathNavigatorBulkFetchPathComplete = /*#__PURE__*/ createAction<{
 }>('PATH_NAV_BULK_FETCH_PATH_COMPLETE');
 
 export const pathNavigatorFetchParentItemsComplete = /*#__PURE__*/ createAction<
-	PayloadWithId<{ items: ContentItem[]; children: GetChildrenResponse }>
+	PayloadWithId<{ items: ContentItem[]; children: GetChildrenResponse; pathFetchRequestId: number }>
 >('PATH_NAV_FETCH_PARENT_ITEMS_COMPLETE');
 
 export const pathNavigatorFetchPathFailed = /*#__PURE__*/ createAction<{

--- a/studio-ui/ui/app/src/state/actions/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/actions/pathNavigator.ts
@@ -95,9 +95,9 @@ export const pathNavigatorFetchPath =
 	/*#__PURE__*/ createAction<PayloadWithId<{ path: string; keyword?: string }>>('PATH_NAV_FETCH_PATH');
 
 export const pathNavigatorFetchPathComplete =
-	/*#__PURE__*/ createAction<PayloadWithId<{ parent?: ContentItem; children: GetChildrenResponse }>>(
-		'PATH_NAV_FETCH_PATH_COMPLETE'
-	);
+	/*#__PURE__*/ createAction<
+		PayloadWithId<{ parent?: ContentItem; children: GetChildrenResponse; pathFetchRequestId?: number }>
+	>('PATH_NAV_FETCH_PATH_COMPLETE');
 
 export const pathNavigatorBulkFetchPathComplete = /*#__PURE__*/ createAction<{
 	paths: PayloadWithId<{ parent?: ContentItem; children: GetChildrenResponse }>[];
@@ -110,6 +110,7 @@ export const pathNavigatorFetchParentItemsComplete = /*#__PURE__*/ createAction<
 export const pathNavigatorFetchPathFailed = /*#__PURE__*/ createAction<{
 	id: string;
 	error: Omit<AjaxError, 'request' | 'xhr'>;
+	pathFetchRequestId?: number;
 }>('PATH_NAV_FETCH_PATH_FAILED');
 
 export const pathNavigatorBulkFetchPathFailed = /*#__PURE__*/ createAction<{

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -72,9 +72,6 @@ import {
 	workflowEventSubmit
 } from '../actions/system';
 import { pushErrorDialog } from '../../utils/system';
-import GlobalState from '../../models/GlobalState';
-
-const getPathFetchRequestId = (state: GlobalState, id: string) => state.pathNavigator[id]?.pathFetchRequestId ?? 0;
 
 export default [
 	// region pathNavigatorInit
@@ -121,21 +118,35 @@ export default [
 					},
 					state
 				]) => {
-					const pathFetchRequestId = getPathFetchRequestId(state, id);
-					return fetchItemWithChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
-						keyword: state.pathNavigator[id].keyword,
-						limit: state.pathNavigator[id].limit,
-						offset: state.pathNavigator[id].offset,
-						excludes: state.pathNavigator[id].excludes,
-						sortStrategy: state.pathNavigator[id].sortStrategy,
-						order: state.pathNavigator[id].order
+					const chunk = state.pathNavigator[id];
+					if (!chunk) {
+						return EMPTY;
+					}
+					const {
+						pathFetchRequestId,
+						currentPath,
+						keyword,
+						limit,
+						offset,
+						excludes,
+						sortStrategy,
+						order,
+						rootPath
+					} = chunk;
+					return fetchItemWithChildrenByPath(state.sites.active, currentPath, {
+						keyword,
+						limit,
+						offset,
+						excludes,
+						sortStrategy,
+						order
 					}).pipe(
 						map(({ item, children }) =>
 							pathNavigatorFetchPathComplete({ id, parent: item, children, pathFetchRequestId })
 						),
 						catchAjaxError((error: AjaxError) => {
-							if (error.status === 404 && state.pathNavigator[id].rootPath !== state.pathNavigator[id].currentPath) {
-								return pathNavigatorConditionallySetPath({ id, path: state.pathNavigator[id].rootPath });
+							if (error.status === 404 && rootPath !== currentPath) {
+								return pathNavigatorConditionallySetPath({ id, path: rootPath });
 							} else {
 								return pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId });
 							}
@@ -157,6 +168,9 @@ export default [
 
 				requests.forEach(({ id }) => {
 					const chunk = state.pathNavigator[id];
+					if (!chunk) {
+						return;
+					}
 					const { currentPath, keyword, limit, offset, excludes, sortStrategy, order } = chunk;
 					paths.push(currentPath);
 					optionsByPath[currentPath] = {
@@ -208,12 +222,12 @@ export default [
 					if (!chunk) {
 						return EMPTY;
 					}
-					const { pathFetchRequestId } = chunk;
+					const { pathFetchRequestId, excludes, limit, sortStrategy, order } = chunk;
 					return fetchItemWithChildrenByPath(state.sites.active, path, {
-						excludes: state.pathNavigator[id].excludes,
-						limit: state.pathNavigator[id].limit,
-						sortStrategy: state.pathNavigator[id].sortStrategy,
-						order: state.pathNavigator[id].order,
+						excludes,
+						limit,
+						sortStrategy,
+						order,
 						...(keyword && { keyword })
 					}).pipe(
 						map(({ item, children }) =>
@@ -239,12 +253,17 @@ export default [
 						payload: { id, path, keyword }
 					},
 					state
-				]) =>
-					fetchItemWithChildrenByPath(state.sites.active, path, {
-						excludes: state.pathNavigator[id].excludes,
-						limit: state.pathNavigator[id].limit,
-						sortStrategy: state.pathNavigator[id].sortStrategy,
-						order: state.pathNavigator[id].order,
+				]) => {
+					const chunk = state.pathNavigator[id];
+					if (!chunk) {
+						return EMPTY;
+					}
+					const { excludes, limit, sortStrategy, order } = chunk;
+					return fetchItemWithChildrenByPath(state.sites.active, path, {
+						excludes,
+						limit,
+						sortStrategy,
+						order,
 						...(keyword && { keyword })
 					}).pipe(
 						map(({ item, children }) =>
@@ -254,7 +273,8 @@ export default [
 							(error) => pathNavigatorConditionallySetPathFailed({ id, error }),
 							(error) => pushErrorDialog({ props: { error: error.response ?? error } })
 						)
-					)
+					);
+				}
 			)
 		),
 	// endregion
@@ -270,10 +290,14 @@ export default [
 					},
 					state
 				]) => {
-					const pathFetchRequestId = getPathFetchRequestId(state, id);
+					const chunk = state.pathNavigator[id];
+					if (!chunk) {
+						return EMPTY;
+					}
+					const { pathFetchRequestId, sortStrategy, order } = chunk;
 					return fetchItemWithChildrenByPath(state.sites.active, path, {
-						sortStrategy: state.pathNavigator[id].sortStrategy,
-						order: state.pathNavigator[id].order
+						sortStrategy,
+						order
 					}).pipe(
 						map(({ item, children }) =>
 							pathNavigatorFetchPathComplete({ id, parent: item, children, pathFetchRequestId })
@@ -297,18 +321,22 @@ export default [
 					},
 					state
 				]) => {
-					const pathFetchRequestId = getPathFetchRequestId(state, id);
-					return fetchChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
+					const chunk = state.pathNavigator[id];
+					if (!chunk) {
+						return EMPTY;
+					}
+					const { pathFetchRequestId, currentPath, limit, sortStrategy, order, excludes } = chunk;
+					return fetchChildrenByPath(state.sites.active, currentPath, {
 						keyword,
-						limit: state.pathNavigator[id].limit,
-						sortStrategy: state.pathNavigator[id].sortStrategy,
-						order: state.pathNavigator[id].order,
-						excludes: state.pathNavigator[id].excludes
+						limit,
+						sortStrategy,
+						order,
+						excludes
 					}).pipe(
 						map((children) =>
 							pathNavigatorFetchPathComplete({
 								id,
-								parent: state.content.itemsByPath[state.pathNavigator[id].currentPath],
+								parent: state.content.itemsByPath[currentPath],
 								children,
 								pathFetchRequestId
 							})
@@ -332,13 +360,17 @@ export default [
 					},
 					state
 				]) => {
-					const pathFetchRequestId = getPathFetchRequestId(state, id);
-					return fetchChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
-						limit: state.pathNavigator[id].limit,
-						sortStrategy: state.pathNavigator[id].sortStrategy,
-						order: state.pathNavigator[id].order,
-						excludes: state.pathNavigator[id].excludes,
-						...(Boolean(state.pathNavigator[id].keyword) && { keyword: state.pathNavigator[id].keyword }),
+					const chunk = state.pathNavigator[id];
+					if (!chunk) {
+						return EMPTY;
+					}
+					const { pathFetchRequestId, currentPath, limit, sortStrategy, order, excludes, keyword } = chunk;
+					return fetchChildrenByPath(state.sites.active, currentPath, {
+						limit,
+						sortStrategy,
+						order,
+						excludes,
+						...(Boolean(keyword) && { keyword }),
 						offset
 					}).pipe(
 						map((children) => pathNavigatorFetchPathComplete({ id, children, pathFetchRequestId })),
@@ -361,9 +393,14 @@ export default [
 					},
 					state
 				]) => {
+					const chunk = state.pathNavigator[id];
+					if (!chunk) {
+						return EMPTY;
+					}
 					const site = state.sites.active;
-					const parentsPath = getIndividualPaths(path, state.pathNavigator[id].rootPath);
-					const pathFetchRequestId = getPathFetchRequestId(state, id);
+					const { rootPath, pathFetchRequestId, sortStrategy: navigatorSortStrategy, order: navigatorOrder } =
+						chunk;
+					const parentsPath = getIndividualPaths(path, rootPath);
 					if (parentsPath.length > 1) {
 						return forkJoin([
 							fetchContentItems(site, parentsPath),
@@ -391,8 +428,8 @@ export default [
 							limit,
 							offset,
 							keyword,
-							sortStrategy: state.pathNavigator[id].sortStrategy,
-							order: state.pathNavigator[id].order
+							sortStrategy: navigatorSortStrategy,
+							order: navigatorOrder
 						}).pipe(
 							map(({ item, children }) =>
 								pathNavigatorFetchPathComplete({ id, parent: item, children, pathFetchRequestId })
@@ -423,13 +460,17 @@ export default [
 					state
 				]) => {
 					if (type !== pathNavigatorConditionallySetPathComplete.type || parent?.childrenCount > 0) {
+						const chunk = state.pathNavigator[id];
+						if (!chunk) {
+							return;
+						}
 						const uuid = state.sites.byId[state.sites.active].uuid;
 						setStoredPathNavigator(uuid, state.user.username, id, {
-							currentPath: state.pathNavigator[id].currentPath,
-							collapsed: state.pathNavigator[id].collapsed,
-							keyword: state.pathNavigator[id].keyword,
-							offset: state.pathNavigator[id].offset,
-							limit: state.pathNavigator[id].limit
+							currentPath: chunk.currentPath,
+							collapsed: chunk.collapsed,
+							keyword: chunk.keyword,
+							offset: chunk.offset,
+							limit: chunk.limit
 						});
 					}
 				}

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -196,20 +196,24 @@ export default [
 						payload: { id, path, keyword }
 					},
 					state
-				]) =>
-					fetchItemWithChildrenByPath(state.sites.active, path, {
+				]) => {
+					const pathFetchRequestId = state.pathNavigator[id]?.pathFetchRequestId;
+					return fetchItemWithChildrenByPath(state.sites.active, path, {
 						excludes: state.pathNavigator[id].excludes,
 						limit: state.pathNavigator[id].limit,
 						sortStrategy: state.pathNavigator[id].sortStrategy,
 						order: state.pathNavigator[id].order,
 						...(keyword && { keyword })
 					}).pipe(
-						map(({ item, children }) => pathNavigatorFetchPathComplete({ id, parent: item, children })),
+						map(({ item, children }) =>
+							pathNavigatorFetchPathComplete({ id, parent: item, children, pathFetchRequestId })
+						),
 						catchAjaxError(
-							(error) => pathNavigatorFetchPathFailed({ id, error }),
+							(error) => pathNavigatorFetchPathFailed({ id, error, pathFetchRequestId }),
 							(error) => pushErrorDialog({ props: { error: error.response ?? error } })
 						)
-					)
+					);
+				}
 			)
 		),
 	// endregion

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -414,7 +414,9 @@ export default [
 								order
 							})
 						]).pipe(
-							map(([items, children]) => pathNavigatorFetchParentItemsComplete({ id, items, children })),
+							map(([items, children]) =>
+								pathNavigatorFetchParentItemsComplete({ id, items, children, pathFetchRequestId })
+							),
 							catchAjaxError((error: AjaxError) => {
 								if (error.status === 404) {
 									return pathNavigatorConditionallySetPath({ id, path: getRootPath(path), pathFetchRequestId });

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -197,7 +197,11 @@ export default [
 					},
 					state
 				]) => {
-					const pathFetchRequestId = state.pathNavigator[id]?.pathFetchRequestId;
+					const chunk = state.pathNavigator[id];
+					if (!chunk) {
+						return EMPTY;
+					}
+					const { pathFetchRequestId } = chunk;
 					return fetchItemWithChildrenByPath(state.sites.active, path, {
 						excludes: state.pathNavigator[id].excludes,
 						limit: state.pathNavigator[id].limit,

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -146,7 +146,7 @@ export default [
 						),
 						catchAjaxError((error: AjaxError) => {
 							if (error.status === 404 && rootPath !== currentPath) {
-								return pathNavigatorConditionallySetPath({ id, path: rootPath });
+								return pathNavigatorConditionallySetPath({ id, path: rootPath, pathFetchRequestId });
 							} else {
 								return pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId });
 							}
@@ -250,12 +250,18 @@ export default [
 			mergeMap(
 				([
 					{
-						payload: { id, path, keyword }
+						payload: { id, path, keyword, pathFetchRequestId }
 					},
 					state
 				]) => {
 					const chunk = state.pathNavigator[id];
 					if (!chunk) {
+						return EMPTY;
+					}
+					if (
+						pathFetchRequestId !== undefined &&
+						pathFetchRequestId !== chunk.pathFetchRequestId
+					) {
 						return EMPTY;
 					}
 					const { excludes, limit, sortStrategy, order } = chunk;
@@ -267,7 +273,13 @@ export default [
 						...(keyword && { keyword })
 					}).pipe(
 						map(({ item, children }) =>
-							pathNavigatorConditionallySetPathComplete({ id, path, parent: item, children })
+							pathNavigatorConditionallySetPathComplete({
+								id,
+								path,
+								parent: item,
+								children,
+								pathFetchRequestId
+							})
 						),
 						catchAjaxError(
 							(error) => pathNavigatorConditionallySetPathFailed({ id, error }),

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -122,17 +122,8 @@ export default [
 					if (!chunk) {
 						return EMPTY;
 					}
-					const {
-						pathFetchRequestId,
-						currentPath,
-						keyword,
-						limit,
-						offset,
-						excludes,
-						sortStrategy,
-						order,
-						rootPath
-					} = chunk;
+					const { pathFetchRequestId, currentPath, keyword, limit, offset, excludes, sortStrategy, order, rootPath } =
+						chunk;
 					return fetchItemWithChildrenByPath(state.sites.active, currentPath, {
 						keyword,
 						limit,
@@ -190,13 +181,15 @@ export default [
 						]).pipe(
 							map(([items, children]) =>
 								pathNavigatorBulkFetchPathComplete({
-									paths: requests.map(({ id }) => ({
-										id,
-										parent: items.find((item) =>
-											item.path.startsWith(withoutIndex(state.pathNavigator[id].currentPath))
-										),
-										children: children[state.pathNavigator[id].currentPath]
-									}))
+									paths: requests
+										.filter(({ id }) => state.pathNavigator[id])
+										.map(({ id }) => ({
+											id,
+											parent: items.find((item) =>
+												item.path.startsWith(withoutIndex(state.pathNavigator[id].currentPath))
+											),
+											children: children[state.pathNavigator[id].currentPath]
+										}))
 								})
 							),
 							catchAjaxError((error) => pathNavigatorBulkFetchPathFailed({ ids: requests.map(({ id }) => id), error }))
@@ -258,10 +251,7 @@ export default [
 					if (!chunk) {
 						return EMPTY;
 					}
-					if (
-						pathFetchRequestId !== undefined &&
-						pathFetchRequestId !== chunk.pathFetchRequestId
-					) {
+					if (pathFetchRequestId !== undefined && pathFetchRequestId !== chunk.pathFetchRequestId) {
 						return EMPTY;
 					}
 					const { excludes, limit, sortStrategy, order } = chunk;
@@ -410,8 +400,7 @@ export default [
 						return EMPTY;
 					}
 					const site = state.sites.active;
-					const { rootPath, pathFetchRequestId, sortStrategy: navigatorSortStrategy, order: navigatorOrder } =
-						chunk;
+					const { rootPath, pathFetchRequestId, sortStrategy: navigatorSortStrategy, order: navigatorOrder } = chunk;
 					const parentsPath = getIndividualPaths(path, rootPath);
 					if (parentsPath.length > 1) {
 						return forkJoin([

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -272,7 +272,7 @@ export default [
 							})
 						),
 						catchAjaxError(
-							(error) => pathNavigatorConditionallySetPathFailed({ id, error }),
+							(error) => pathNavigatorConditionallySetPathFailed({ id, error, pathFetchRequestId }),
 							(error) => pushErrorDialog({ props: { error: error.response ?? error } })
 						)
 					);

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -428,7 +428,7 @@ export default [
 							map(([items, children]) => pathNavigatorFetchParentItemsComplete({ id, items, children })),
 							catchAjaxError((error: AjaxError) => {
 								if (error.status === 404) {
-									return pathNavigatorConditionallySetPath({ id, path: getRootPath(path) });
+									return pathNavigatorConditionallySetPath({ id, path: getRootPath(path), pathFetchRequestId });
 								} else {
 									return pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId });
 								}

--- a/studio-ui/ui/app/src/state/epics/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/epics/pathNavigator.ts
@@ -72,6 +72,9 @@ import {
 	workflowEventSubmit
 } from '../actions/system';
 import { pushErrorDialog } from '../../utils/system';
+import GlobalState from '../../models/GlobalState';
+
+const getPathFetchRequestId = (state: GlobalState, id: string) => state.pathNavigator[id]?.pathFetchRequestId ?? 0;
 
 export default [
 	// region pathNavigatorInit
@@ -117,8 +120,9 @@ export default [
 						payload: { id }
 					},
 					state
-				]) =>
-					fetchItemWithChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
+				]) => {
+					const pathFetchRequestId = getPathFetchRequestId(state, id);
+					return fetchItemWithChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
 						keyword: state.pathNavigator[id].keyword,
 						limit: state.pathNavigator[id].limit,
 						offset: state.pathNavigator[id].offset,
@@ -126,15 +130,18 @@ export default [
 						sortStrategy: state.pathNavigator[id].sortStrategy,
 						order: state.pathNavigator[id].order
 					}).pipe(
-						map(({ item, children }) => pathNavigatorFetchPathComplete({ id, parent: item, children })),
+						map(({ item, children }) =>
+							pathNavigatorFetchPathComplete({ id, parent: item, children, pathFetchRequestId })
+						),
 						catchAjaxError((error: AjaxError) => {
 							if (error.status === 404 && state.pathNavigator[id].rootPath !== state.pathNavigator[id].currentPath) {
 								return pathNavigatorConditionallySetPath({ id, path: state.pathNavigator[id].rootPath });
 							} else {
-								return pathNavigatorFetchPathFailed({ error, id });
+								return pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId });
 							}
 						})
-					)
+					);
+				}
 			)
 		),
 	// endregion
@@ -262,14 +269,18 @@ export default [
 						payload: { id, path }
 					},
 					state
-				]) =>
-					fetchItemWithChildrenByPath(state.sites.active, path, {
+				]) => {
+					const pathFetchRequestId = getPathFetchRequestId(state, id);
+					return fetchItemWithChildrenByPath(state.sites.active, path, {
 						sortStrategy: state.pathNavigator[id].sortStrategy,
 						order: state.pathNavigator[id].order
 					}).pipe(
-						map(({ item, children }) => pathNavigatorFetchPathComplete({ id, parent: item, children })),
-						catchAjaxError((error) => pathNavigatorFetchPathFailed({ error, id }))
-					)
+						map(({ item, children }) =>
+							pathNavigatorFetchPathComplete({ id, parent: item, children, pathFetchRequestId })
+						),
+						catchAjaxError((error) => pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId }))
+					);
+				}
 			)
 		),
 	// endregion
@@ -285,8 +296,9 @@ export default [
 						payload: { id, keyword }
 					},
 					state
-				]) =>
-					fetchChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
+				]) => {
+					const pathFetchRequestId = getPathFetchRequestId(state, id);
+					return fetchChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
 						keyword,
 						limit: state.pathNavigator[id].limit,
 						sortStrategy: state.pathNavigator[id].sortStrategy,
@@ -297,11 +309,13 @@ export default [
 							pathNavigatorFetchPathComplete({
 								id,
 								parent: state.content.itemsByPath[state.pathNavigator[id].currentPath],
-								children
+								children,
+								pathFetchRequestId
 							})
 						),
-						catchAjaxError((error) => pathNavigatorFetchPathFailed({ error, id }))
-					)
+						catchAjaxError((error) => pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId }))
+					);
+				}
 			)
 		),
 	// endregion
@@ -317,8 +331,9 @@ export default [
 						payload: { id, offset }
 					},
 					state
-				]) =>
-					fetchChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
+				]) => {
+					const pathFetchRequestId = getPathFetchRequestId(state, id);
+					return fetchChildrenByPath(state.sites.active, state.pathNavigator[id].currentPath, {
 						limit: state.pathNavigator[id].limit,
 						sortStrategy: state.pathNavigator[id].sortStrategy,
 						order: state.pathNavigator[id].order,
@@ -326,9 +341,10 @@ export default [
 						...(Boolean(state.pathNavigator[id].keyword) && { keyword: state.pathNavigator[id].keyword }),
 						offset
 					}).pipe(
-						map((children) => pathNavigatorFetchPathComplete({ id, children })),
-						catchAjaxError((error) => pathNavigatorFetchPathFailed({ error, id }))
-					)
+						map((children) => pathNavigatorFetchPathComplete({ id, children, pathFetchRequestId })),
+						catchAjaxError((error) => pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId }))
+					);
+				}
 			)
 		),
 	// endregion
@@ -347,6 +363,7 @@ export default [
 				]) => {
 					const site = state.sites.active;
 					const parentsPath = getIndividualPaths(path, state.pathNavigator[id].rootPath);
+					const pathFetchRequestId = getPathFetchRequestId(state, id);
 					if (parentsPath.length > 1) {
 						return forkJoin([
 							fetchContentItems(site, parentsPath),
@@ -364,7 +381,7 @@ export default [
 								if (error.status === 404) {
 									return pathNavigatorConditionallySetPath({ id, path: getRootPath(path) });
 								} else {
-									return pathNavigatorFetchPathFailed({ error, id });
+									return pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId });
 								}
 							})
 						);
@@ -377,8 +394,10 @@ export default [
 							sortStrategy: state.pathNavigator[id].sortStrategy,
 							order: state.pathNavigator[id].order
 						}).pipe(
-							map(({ item, children }) => pathNavigatorFetchPathComplete({ id, parent: item, children })),
-							catchAjaxError((error) => pathNavigatorFetchPathFailed({ error, id }))
+							map(({ item, children }) =>
+								pathNavigatorFetchPathComplete({ id, parent: item, children, pathFetchRequestId })
+							),
+							catchAjaxError((error) => pathNavigatorFetchPathFailed({ error, id, pathFetchRequestId }))
 						);
 					}
 				}

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -262,8 +262,15 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			chunk.currentPath = path;
 			chunk.error = null;
 		})
-		.addCase(pathNavigatorFetchParentItemsComplete, (state, { payload: { id, children } }) => {
+		.addCase(pathNavigatorFetchParentItemsComplete, (state, { payload: { id, children, pathFetchRequestId } }) => {
 			const chunk = state[id];
+			if (!chunk) {
+				return;
+			}
+			if (pathFetchRequestId !== chunk.pathFetchRequestId) {
+				return;
+			}
+			clearRevertPathForRequest(chunk, pathFetchRequestId);
 			const { currentPath, rootPath } = chunk;
 			chunk.itemsInPath = children.map((item) => item.path);
 			chunk.levelDescriptor = children.levelDescriptor?.path ?? null;

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -204,8 +204,15 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			}
 		)
 		.addCase(pathNavigatorConditionallySetPathFailed, (state, { payload }) => {
-			state[payload.id].isFetching = false;
-			state[payload.id].error = payload.error;
+			const chunk = state[payload.id];
+			if (!chunk) {
+				return;
+			}
+			if (payload.pathFetchRequestId !== undefined && payload.pathFetchRequestId !== chunk.pathFetchRequestId) {
+				return;
+			}
+			chunk.isFetching = false;
+			chunk.error = payload.error;
 		})
 		.addCase(pathNavigatorFetchPath, (state, { payload }) => {
 			const chunk = state[payload.id];

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -59,22 +59,17 @@ const bumpPathFetchRequestId = (chunk: { pathFetchRequestId?: number }): number 
 
 type PathNavigatorChunk = GlobalState['pathNavigator'][string];
 
-const recordRevertPathForRequest = (chunk: PathNavigatorChunk, pathFetchRequestId: number) => {
-	if (!chunk.revertPathByRequestId) {
-		chunk.revertPathByRequestId = {};
-	}
-	chunk.revertPathByRequestId[pathFetchRequestId] = chunk.currentPath;
+// A path-changing fetch sets `currentPath` optimistically, before its result is in. Reverting a failed
+// fetch to whatever `currentPath` held at dispatch time is unsafe, because a superseded fetch may have
+// left an optimistic path there that no `itemsInPath`/`breadcrumb` ever described. Only a path confirmed
+// by an applied result is a safe target to revert to.
+const confirmPath = (chunk: PathNavigatorChunk, path: string) => {
+	chunk.lastConfirmedPath = path;
 };
 
-const clearRevertPathForRequest = (chunk: PathNavigatorChunk, pathFetchRequestId: number) => {
-	delete chunk.revertPathByRequestId?.[pathFetchRequestId];
-};
-
-const restoreRevertPathForRequest = (chunk: PathNavigatorChunk, pathFetchRequestId: number) => {
-	const revertPath = chunk.revertPathByRequestId?.[pathFetchRequestId];
-	if (revertPath !== undefined) {
-		chunk.currentPath = revertPath;
-		clearRevertPathForRequest(chunk, pathFetchRequestId);
+const revertToLastConfirmedPath = (chunk: PathNavigatorChunk) => {
+	if (chunk.lastConfirmedPath !== undefined) {
+		chunk.currentPath = chunk.lastConfirmedPath;
 	}
 };
 
@@ -87,6 +82,7 @@ const updatePath = (state, payload) => {
 		const chunk = state[id];
 		const path = parent?.path ?? state[id].currentPath;
 		chunk.currentPath = path;
+		confirmPath(chunk, path);
 		chunk.breadcrumb = getIndividualPaths(withoutIndex(path), withoutIndex(state[id].rootPath));
 		chunk.itemsInPath = children.length === 0 ? [] : children.map((item) => item.path);
 		chunk.levelDescriptor = children.levelDescriptor?.path;
@@ -138,6 +134,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 				id,
 				rootPath,
 				currentPath: currentPath,
+				lastConfirmedPath: currentPath,
 				localeCode: locale,
 				keyword: keyword,
 				isSelectMode: false,
@@ -166,8 +163,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			chunk.keyword = '';
 			chunk.error = null;
 			chunk.isFetching = true;
-			const pathFetchRequestId = bumpPathFetchRequestId(chunk);
-			recordRevertPathForRequest(chunk, pathFetchRequestId);
+			bumpPathFetchRequestId(chunk);
 			chunk.currentPath = path;
 		})
 		.addCase(pathNavigatorConditionallySetPath, (state, { payload: { id, pathFetchRequestId } }) => {
@@ -195,6 +191,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 				chunk.error = null;
 				if (parent.childrenCount > 0) {
 					chunk.currentPath = path;
+					confirmPath(chunk, path);
 					chunk.offset = 0;
 					chunk.breadcrumb = getIndividualPaths(withoutIndex(path), withoutIndex(state[id].rootPath));
 					chunk.itemsInPath = children.map((item) => item.path);
@@ -219,11 +216,10 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (!chunk) {
 				return;
 			}
-			const pathFetchRequestId = bumpPathFetchRequestId(chunk);
+			bumpPathFetchRequestId(chunk);
 			chunk.isFetching = true;
 			chunk.error = null;
 			if (payload.path) {
-				recordRevertPathForRequest(chunk, pathFetchRequestId);
 				chunk.currentPath = payload.path;
 			}
 		})
@@ -235,7 +231,6 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (payload.pathFetchRequestId !== chunk.pathFetchRequestId) {
 				return;
 			}
-			clearRevertPathForRequest(chunk, payload.pathFetchRequestId);
 			updatePath(state, payload);
 		})
 		.addCase(pathNavigatorBulkFetchPathComplete, (state, { payload: { paths } }) => {
@@ -253,7 +248,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			}
 			chunk.isFetching = false;
 			chunk.error = error;
-			restoreRevertPathForRequest(chunk, pathFetchRequestId);
+			revertToLastConfirmedPath(chunk);
 		})
 		.addCase(pathNavigatorBulkFetchPathFailed, (state, { payload: { ids, error } }) => {
 			ids.forEach((id) => {
@@ -263,8 +258,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 		})
 		.addCase(pathNavigatorFetchParentItems, (state, { payload: { id, path } }) => {
 			const chunk = state[id];
-			const pathFetchRequestId = bumpPathFetchRequestId(chunk);
-			recordRevertPathForRequest(chunk, pathFetchRequestId);
+			bumpPathFetchRequestId(chunk);
 			chunk.isFetching = true;
 			chunk.currentPath = path;
 			chunk.error = null;
@@ -277,8 +271,8 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (pathFetchRequestId !== chunk.pathFetchRequestId) {
 				return;
 			}
-			clearRevertPathForRequest(chunk, pathFetchRequestId);
 			const { currentPath, rootPath } = chunk;
+			confirmPath(chunk, currentPath);
 			chunk.itemsInPath = children.map((item) => item.path);
 			chunk.levelDescriptor = children.levelDescriptor?.path ?? null;
 			chunk.breadcrumb = getIndividualPaths(withoutIndex(currentPath), withoutIndex(rootPath));

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -161,10 +161,23 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			state[payload.id].error = payload.error;
 		})
 		.addCase(pathNavigatorFetchPath, (state, { payload }) => {
-			state[payload.id].isFetching = true;
-			state[payload.id].error = null;
+			const chunk = state[payload.id];
+			if (!chunk) {
+				return;
+			}
+			chunk.isFetching = true;
+			chunk.error = null;
+			if (payload.path) {
+				chunk.revertPath = chunk.currentPath;
+				chunk.currentPath = payload.path;
+			}
 		})
 		.addCase(pathNavigatorFetchPathComplete, (state, { payload }) => {
+			const chunk = state[payload.id];
+			if (!chunk) {
+				return;
+			}
+			delete chunk.revertPath;
 			updatePath(state, payload);
 		})
 		.addCase(pathNavigatorBulkFetchPathComplete, (state, { payload: { paths } }) => {
@@ -173,8 +186,17 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			});
 		})
 		.addCase(pathNavigatorFetchPathFailed, (state, { payload: { id, error } }) => {
-			state[id].isFetching = false;
-			state[id].error = error;
+			const chunk = state[id];
+			if (!chunk) {
+				return;
+			}
+			chunk.isFetching = false;
+			chunk.error = error;
+
+			if (chunk.revertPath) {
+				chunk.currentPath = chunk.revertPath;
+				delete chunk.revertPath;
+			}
 		})
 		.addCase(pathNavigatorBulkFetchPathFailed, (state, { payload: { ids, error } }) => {
 			ids.forEach((id) => {

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -165,6 +165,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			const chunk = state[id];
 			chunk.keyword = '';
 			chunk.error = null;
+			chunk.isFetching = true;
 			const pathFetchRequestId = bumpPathFetchRequestId(chunk);
 			recordRevertPathForRequest(chunk, pathFetchRequestId);
 			chunk.currentPath = path;

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -57,6 +57,27 @@ const bumpPathFetchRequestId = (chunk: { pathFetchRequestId?: number }): number 
 	return chunk.pathFetchRequestId;
 };
 
+type PathNavigatorChunk = GlobalState['pathNavigator'][string];
+
+const recordRevertPathForRequest = (chunk: PathNavigatorChunk, pathFetchRequestId: number) => {
+	if (!chunk.revertPathByRequestId) {
+		chunk.revertPathByRequestId = {};
+	}
+	chunk.revertPathByRequestId[pathFetchRequestId] = chunk.currentPath;
+};
+
+const clearRevertPathForRequest = (chunk: PathNavigatorChunk, pathFetchRequestId: number) => {
+	delete chunk.revertPathByRequestId?.[pathFetchRequestId];
+};
+
+const restoreRevertPathForRequest = (chunk: PathNavigatorChunk, pathFetchRequestId: number) => {
+	const revertPath = chunk.revertPathByRequestId?.[pathFetchRequestId];
+	if (revertPath !== undefined) {
+		chunk.currentPath = revertPath;
+		clearRevertPathForRequest(chunk, pathFetchRequestId);
+	}
+};
+
 const updatePath = (state, payload) => {
 	const { id, parent, children } = payload;
 	if (
@@ -143,9 +164,10 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 		.addCase(pathNavigatorSetCurrentPath, (state, { payload: { id, path } }) => {
 			const chunk = state[id];
 			chunk.keyword = '';
-			chunk.currentPath = path;
 			chunk.error = null;
-			bumpPathFetchRequestId(chunk);
+			const pathFetchRequestId = bumpPathFetchRequestId(chunk);
+			recordRevertPathForRequest(chunk, pathFetchRequestId);
+			chunk.currentPath = path;
 		})
 		.addCase(pathNavigatorConditionallySetPath, (state, { payload: { id, pathFetchRequestId } }) => {
 			const chunk = state[id];
@@ -189,11 +211,11 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (!chunk) {
 				return;
 			}
-			bumpPathFetchRequestId(chunk);
+			const pathFetchRequestId = bumpPathFetchRequestId(chunk);
 			chunk.isFetching = true;
 			chunk.error = null;
 			if (payload.path) {
-				chunk.revertPath = chunk.currentPath;
+				recordRevertPathForRequest(chunk, pathFetchRequestId);
 				chunk.currentPath = payload.path;
 			}
 		})
@@ -205,7 +227,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (payload.pathFetchRequestId !== chunk.pathFetchRequestId) {
 				return;
 			}
-			delete chunk.revertPath;
+			clearRevertPathForRequest(chunk, payload.pathFetchRequestId);
 			updatePath(state, payload);
 		})
 		.addCase(pathNavigatorBulkFetchPathComplete, (state, { payload: { paths } }) => {
@@ -223,11 +245,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			}
 			chunk.isFetching = false;
 			chunk.error = error;
-
-			if (chunk.revertPath) {
-				chunk.currentPath = chunk.revertPath;
-				delete chunk.revertPath;
-			}
+			restoreRevertPathForRequest(chunk, pathFetchRequestId);
 		})
 		.addCase(pathNavigatorBulkFetchPathFailed, (state, { payload: { ids, error } }) => {
 			ids.forEach((id) => {
@@ -237,7 +255,8 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 		})
 		.addCase(pathNavigatorFetchParentItems, (state, { payload: { id, path } }) => {
 			const chunk = state[id];
-			bumpPathFetchRequestId(chunk);
+			const pathFetchRequestId = bumpPathFetchRequestId(chunk);
+			recordRevertPathForRequest(chunk, pathFetchRequestId);
 			chunk.isFetching = true;
 			chunk.currentPath = path;
 			chunk.error = null;

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -165,6 +165,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (!chunk) {
 				return;
 			}
+			chunk.pathFetchRequestId = (chunk.pathFetchRequestId ?? 0) + 1;
 			chunk.isFetching = true;
 			chunk.error = null;
 			if (payload.path) {
@@ -177,6 +178,12 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (!chunk) {
 				return;
 			}
+			if (
+				payload.pathFetchRequestId !== undefined &&
+				payload.pathFetchRequestId !== chunk.pathFetchRequestId
+			) {
+				return;
+			}
 			delete chunk.revertPath;
 			updatePath(state, payload);
 		})
@@ -185,9 +192,12 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 				updatePath(state, path);
 			});
 		})
-		.addCase(pathNavigatorFetchPathFailed, (state, { payload: { id, error } }) => {
+		.addCase(pathNavigatorFetchPathFailed, (state, { payload: { id, error, pathFetchRequestId } }) => {
 			const chunk = state[id];
 			if (!chunk) {
+				return;
+			}
+			if (pathFetchRequestId !== undefined && pathFetchRequestId !== chunk.pathFetchRequestId) {
 				return;
 			}
 			chunk.isFetching = false;

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -26,6 +26,7 @@ import {
 	pathNavigatorConditionallySetPath,
 	pathNavigatorConditionallySetPathComplete,
 	pathNavigatorConditionallySetPathFailed,
+	pathNavigatorBackgroundRefresh,
 	pathNavigatorFetchParentItems,
 	pathNavigatorFetchParentItemsComplete,
 	pathNavigatorFetchPath,
@@ -50,6 +51,11 @@ import SocketEvent, { MoveContentEventPayload } from '../../models/SocketEvent';
 import StandardAction from '../../models/StandardAction';
 import { CaseReducer } from '@reduxjs/toolkit/src/createReducer';
 import GlobalState from '../../models/GlobalState';
+
+const bumpPathFetchRequestId = (chunk: { pathFetchRequestId?: number }): number => {
+	chunk.pathFetchRequestId = (chunk.pathFetchRequestId ?? 0) + 1;
+	return chunk.pathFetchRequestId;
+};
 
 const updatePath = (state, payload) => {
 	const { id, parent, children } = payload;
@@ -135,9 +141,11 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			state[id].localeCode = locale;
 		})
 		.addCase(pathNavigatorSetCurrentPath, (state, { payload: { id, path } }) => {
-			state[id].keyword = '';
-			state[id].currentPath = path;
-			state[id].error = null;
+			const chunk = state[id];
+			chunk.keyword = '';
+			chunk.currentPath = path;
+			chunk.error = null;
+			bumpPathFetchRequestId(chunk);
 		})
 		.addCase(pathNavigatorConditionallySetPath, (state, { payload }) => {
 			state[payload.id].isFetching = true;
@@ -165,7 +173,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (!chunk) {
 				return;
 			}
-			chunk.pathFetchRequestId = (chunk.pathFetchRequestId ?? 0) + 1;
+			bumpPathFetchRequestId(chunk);
 			chunk.isFetching = true;
 			chunk.error = null;
 			if (payload.path) {
@@ -178,10 +186,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (!chunk) {
 				return;
 			}
-			if (
-				payload.pathFetchRequestId !== undefined &&
-				payload.pathFetchRequestId !== chunk.pathFetchRequestId
-			) {
+			if (payload.pathFetchRequestId !== chunk.pathFetchRequestId) {
 				return;
 			}
 			delete chunk.revertPath;
@@ -197,7 +202,7 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			if (!chunk) {
 				return;
 			}
-			if (pathFetchRequestId !== undefined && pathFetchRequestId !== chunk.pathFetchRequestId) {
+			if (pathFetchRequestId !== chunk.pathFetchRequestId) {
 				return;
 			}
 			chunk.isFetching = false;
@@ -215,9 +220,11 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			});
 		})
 		.addCase(pathNavigatorFetchParentItems, (state, { payload: { id, path } }) => {
-			state[id].isFetching = true;
-			state[id].currentPath = path;
-			state[id].error = null;
+			const chunk = state[id];
+			bumpPathFetchRequestId(chunk);
+			chunk.isFetching = true;
+			chunk.currentPath = path;
+			chunk.error = null;
 		})
 		.addCase(pathNavigatorFetchParentItemsComplete, (state, { payload: { id, children } }) => {
 			const chunk = state[id];
@@ -235,8 +242,10 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 		})
 		.addCase(pathNavigatorSetKeyword, (state, { payload: { id, keyword } }) => {
 			if (keyword !== (state.keyword as unknown as string)) {
-				state[id].keyword = keyword;
-				state[id].isFetching = true;
+				const chunk = state[id];
+				chunk.keyword = keyword;
+				bumpPathFetchRequestId(chunk);
+				chunk.isFetching = true;
 			}
 		})
 		.addCase(pathNavigatorItemChecked, (state, { payload: { id, item } }) => {
@@ -253,7 +262,12 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			Object.assign(state[payload.id], payload);
 		})
 		.addCase(pathNavigatorRefresh, (state, { payload: { id } }) => {
-			state[id].isFetching = true;
+			const chunk = state[id];
+			bumpPathFetchRequestId(chunk);
+			chunk.isFetching = true;
+		})
+		.addCase(pathNavigatorBackgroundRefresh, (state, { payload: { id } }) => {
+			bumpPathFetchRequestId(state[id]);
 		})
 		.addCase(pathNavigatorBulkRefresh, (state, { payload: { requests } }) => {
 			requests.forEach(({ id, backgroundRefresh }) => {
@@ -262,11 +276,15 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			});
 		})
 		.addCase(pathNavigatorChangePage, (state, { payload: { id } }) => {
-			state[id].isFetching = true;
+			const chunk = state[id];
+			bumpPathFetchRequestId(chunk);
+			chunk.isFetching = true;
 		})
 		.addCase(pathNavigatorChangeLimit, (state, { payload: { id, limit } }) => {
-			state[id].limit = limit;
-			state[id].isFetching = true;
+			const chunk = state[id];
+			chunk.limit = limit;
+			bumpPathFetchRequestId(chunk);
+			chunk.isFetching = true;
 		})
 		.addCase(changeSiteComplete, () => ({}))
 		.addCase(fetchSiteUiConfig, () => ({}))

--- a/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
+++ b/studio-ui/ui/app/src/state/reducers/pathNavigator.ts
@@ -147,23 +147,39 @@ const reducer = createReducer<GlobalState['pathNavigator']>({}, (builder) => {
 			chunk.error = null;
 			bumpPathFetchRequestId(chunk);
 		})
-		.addCase(pathNavigatorConditionallySetPath, (state, { payload }) => {
-			state[payload.id].isFetching = true;
-			state[payload.id].error = null;
-		})
-		.addCase(pathNavigatorConditionallySetPathComplete, (state, { payload: { id, path, parent, children } }) => {
+		.addCase(pathNavigatorConditionallySetPath, (state, { payload: { id, pathFetchRequestId } }) => {
 			const chunk = state[id];
-			chunk.isFetching = false;
-			chunk.error = null;
-			if (parent.childrenCount > 0) {
-				chunk.currentPath = path;
-				chunk.offset = 0;
-				chunk.breadcrumb = getIndividualPaths(withoutIndex(path), withoutIndex(state[id].rootPath));
-				chunk.itemsInPath = children.map((item) => item.path);
-				chunk.levelDescriptor = children.levelDescriptor?.path;
-				chunk.total = children.total;
+			if (!chunk) {
+				return;
 			}
+			if (pathFetchRequestId !== undefined && pathFetchRequestId !== chunk.pathFetchRequestId) {
+				return;
+			}
+			chunk.isFetching = true;
+			chunk.error = null;
 		})
+		.addCase(
+			pathNavigatorConditionallySetPathComplete,
+			(state, { payload: { id, path, parent, children, pathFetchRequestId } }) => {
+				const chunk = state[id];
+				if (!chunk) {
+					return;
+				}
+				if (pathFetchRequestId !== undefined && pathFetchRequestId !== chunk.pathFetchRequestId) {
+					return;
+				}
+				chunk.isFetching = false;
+				chunk.error = null;
+				if (parent.childrenCount > 0) {
+					chunk.currentPath = path;
+					chunk.offset = 0;
+					chunk.breadcrumb = getIndividualPaths(withoutIndex(path), withoutIndex(state[id].rootPath));
+					chunk.itemsInPath = children.map((item) => item.path);
+					chunk.levelDescriptor = children.levelDescriptor?.path;
+					chunk.total = children.total;
+				}
+			}
+		)
 		.addCase(pathNavigatorConditionallySetPathFailed, (state, { payload }) => {
 			state[payload.id].isFetching = false;
 			state[payload.id].error = payload.error;


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms-e/issues/1227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path navigation reliability during rapid or concurrent navigation by matching each request to its corresponding result.
  - When a path load is superseded or fails, the navigator now restores the previously viewed path.
  - Navigation loading and error states now update more consistently across refresh, pagination, keyword changes, and background refresh.
  - Prevented unexpected failures by safely handling cases where navigator state is missing during a path request, including refresh and persistence updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->