### PR TITLE
Fix cli deploy to match gradle application plugin layout

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -60,7 +60,7 @@ tasks.named('startScripts') {
 
 tasks.register('assembleCliDistribution', Sync) {
 	group = 'build'
-	description = 'Assembles the CLI distribution (bin + repo), matching Maven appassembler layout'
+	description = 'Assembles the CLI distribution (bin + lib), matching the Gradle application plugin layout'
 	dependsOn tasks.named('startScripts'), configurations.runtimeClasspath, tasks.named('jar')
 	into layout.buildDirectory.dir('cli')
 
@@ -68,10 +68,10 @@ tasks.register('assembleCliDistribution', Sync) {
 		into 'bin'
 	}
 	from(configurations.runtimeClasspath) {
-		into 'repo'
+		into 'lib'
 	}
 	from(tasks.named('jar')) {
-		into 'repo'
+		into 'lib'
 	}
 }
 


### PR DESCRIPTION
Fix cli deploy to match gradle application plugin layout
https://github.com/craftersoftware/craftercms/issues/8829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CLI distribution packaging to use the standard `bin` and `lib` directory layout.
  * Runtime dependencies and the application JAR are now packaged under `lib` for improved compatibility with the generated startup scripts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->