### PR TITLE
Remove opensearch and jgit from dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,14 +26,6 @@ updates:
                 patterns:
                     - "*"
         ignore:
-            -   dependency-name: "org.opensearch.client:opensearch-rest-high-level-client"
-                versions: [ ">=3.0.0" ]
-            -   dependency-name: "org.opensearch.client:opensearch-java"
-                versions: [ ">=3.0.0" ]
-            -   dependency-name: "org.codelibs.opensearch:opensearch-runner"
-                versions: [ ">=3.0.0" ]
-            -   dependency-name: "org.eclipse.jgit:org.eclipse.jgit"
-                versions: [ ">7.0.1.202505221510-r" ]
             -   dependency-name: "org.apache.groovy:groovy"
                 versions: [ ">=5.0.0" ]
             -   dependency-name: "org.apache.groovy:groovy-all"


### PR DESCRIPTION
Remove opensearch and jgit from dependabot ignores
https://github.com/craftersoftware/craftercms-e/issues/1262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings so previously excluded dependencies can be considered for updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->