### PR TITLE
Set the node memory allocation in build script

### DIFF
--- a/studio-ui/ui/app/package.json
+++ b/studio-ui/ui/app/package.json
@@ -30,7 +30,7 @@
 		"start": "vite",
 		"build": "run-s compile build:worker build:vite",
 		"lint": "eslint .",
-		"build:vite": "vite build",
+		"build:vite": "NODE_OPTIONS=--max-old-space-size=4096 vite build",
 		"build:worker": "rollup -c rollup.config.mjs --environment PRODUCTION",
 		"build:worker:dev": "rollup -c rollup.config.mjs --environment PRODUCTION:false",
 		"build:worker:npm": "rollup -c rollup.config.mjs --environment NPM",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability by increasing the memory available during production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->