### PR TITLE
[8854] Diff dialog not highlighting differences

### DIFF
--- a/studio-ui/ui/app/package.json
+++ b/studio-ui/ui/app/package.json
@@ -63,7 +63,6 @@
 		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.1",
 		"@graphiql/plugin-explorer": "^5.1.1",
-		"@monaco-editor/react": "^4.7.0",
 		"@mui/icons-material": "^7.3.9",
 		"@mui/lab": "7.0.1-beta.23",
 		"@mui/material": "^7.3.9",

--- a/studio-ui/ui/app/src/components/CompareVersionsDialog/CompareFieldPanel.tsx
+++ b/studio-ui/ui/app/src/components/CompareVersionsDialog/CompareFieldPanel.tsx
@@ -26,7 +26,7 @@ import { ErrorBoundary } from '../ErrorBoundary';
 import { initialFieldViewState, useVersionsDialogContext } from './VersionsDialogContext';
 import DefaultDiffView from './FieldsTypesDiffViews/DefaultDiffView';
 import TextDiffView from './FieldsTypesDiffViews/TextDiffView';
-import { DiffEditorProps } from '@monaco-editor/react';
+import { MonacoDiffEditorProps } from '../MonacoEditor';
 import ContentInstance from '../../models/ContentInstance';
 
 export interface CompareFieldPanelProps {
@@ -38,7 +38,7 @@ export interface CompareFieldPanelProps {
 }
 
 export interface DiffComponentProps extends Pick<DiffViewComponentBaseProps, 'aXml' | 'bXml' | 'field'> {
-	editorProps?: DiffEditorProps;
+	editorProps?: MonacoDiffEditorProps;
 }
 
 export function CompareFieldPanel(props: CompareFieldPanelProps) {

--- a/studio-ui/ui/app/src/components/CompareVersionsDialog/CompareVersionsDialog.tsx
+++ b/studio-ui/ui/app/src/components/CompareVersionsDialog/CompareVersionsDialog.tsx
@@ -32,7 +32,7 @@ import Drawer, { drawerClasses } from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
 import { DialogHeader } from '../DialogHeader';
 import ViewVersionDialogContainer from '../ViewVersionDialog/ViewVersionDialogContainer';
-import { DiffEditorProps } from '@monaco-editor/react';
+import { MonacoDiffEditorOptions } from '../MonacoEditor';
 import {
 	dialogInitialState,
 	FieldViewState,
@@ -87,7 +87,7 @@ export function CompareVersionsDialog(props: CompareVersionsDialogProps) {
 					fieldsViewState: { ...state.fieldsViewState, [fieldId]: { ...state.fieldsViewState[fieldId], ...viewState } }
 				});
 			},
-			setFieldViewEditorOptionsState(fieldId: string, options: DiffEditorProps['options']) {
+			setFieldViewEditorOptionsState(fieldId: string, options: MonacoDiffEditorOptions) {
 				setState({
 					...state,
 					fieldsViewState: {

--- a/studio-ui/ui/app/src/components/CompareVersionsDialog/FieldsTypesDiffViews/DefaultDiffView.tsx
+++ b/studio-ui/ui/app/src/components/CompareVersionsDialog/FieldsTypesDiffViews/DefaultDiffView.tsx
@@ -17,10 +17,10 @@
 import React from 'react';
 import TextDiffView from './TextDiffView';
 import { DiffViewComponentBaseProps } from '../utils';
-import { DiffEditorProps } from '@monaco-editor/react';
+import { MonacoDiffEditorProps } from '../../MonacoEditor';
 
 export interface DefaultDiffViewProps extends Pick<DiffViewComponentBaseProps, 'aXml' | 'bXml'> {
-	editorProps?: DiffEditorProps;
+	editorProps?: MonacoDiffEditorProps;
 }
 
 export function DefaultDiffView(props: DefaultDiffViewProps) {

--- a/studio-ui/ui/app/src/components/CompareVersionsDialog/FieldsTypesDiffViews/FileNameDiffView.tsx
+++ b/studio-ui/ui/app/src/components/CompareVersionsDialog/FieldsTypesDiffViews/FileNameDiffView.tsx
@@ -16,14 +16,14 @@
 
 import React from 'react';
 import { DiffViewComponentBaseProps } from '../utils';
-import { DiffEditorProps } from '@monaco-editor/react';
+import { MonacoDiffEditorProps } from '../../MonacoEditor';
 import { fromString } from '../../../utils/xml';
 import { getContentFileNameFromPath } from '../../../utils/content';
 import TextDiffView from './TextDiffView';
 import { XmlKeys } from '../../FormsEngine/lib/formConsts';
 
 export interface FileNameDiffViewProps extends Pick<DiffViewComponentBaseProps, 'aXml' | 'bXml'> {
-	editorProps?: DiffEditorProps;
+	editorProps?: MonacoDiffEditorProps;
 }
 
 export function FileNameDiffView(props: FileNameDiffViewProps) {

--- a/studio-ui/ui/app/src/components/CompareVersionsDialog/FieldsTypesDiffViews/TextDiffView.tsx
+++ b/studio-ui/ui/app/src/components/CompareVersionsDialog/FieldsTypesDiffViews/TextDiffView.tsx
@@ -15,7 +15,7 @@
  */
 
 import { ContentTypeField } from '../../../models';
-import { DiffEditor, DiffEditorProps } from '@monaco-editor/react';
+import { MonacoDiffEditor, MonacoDiffEditorProps } from '../../MonacoEditor';
 import { useVersionsDialogContext } from '../VersionsDialogContext';
 import { DiffViewComponentBaseProps, removeTags } from '../utils';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -27,7 +27,7 @@ import { textViewLanguageMap } from '../../ViewVersionDialog/utils';
 
 export interface TextDiffViewProps extends Pick<DiffViewComponentBaseProps, 'aXml' | 'bXml'> {
 	field?: ContentTypeField;
-	editorProps?: DiffEditorProps;
+	editorProps?: MonacoDiffEditorProps;
 }
 
 export function TextDiffView(props: TextDiffViewProps) {
@@ -51,7 +51,7 @@ export function TextDiffView(props: TextDiffViewProps) {
 	const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 	const language = textViewLanguageMap[field?.type] || 'xml';
 
-	const monacoOptions: DiffEditorProps['options'] = {
+	const monacoOptions: MonacoDiffEditorProps['options'] = {
 		readOnly: true,
 		automaticLayout: true,
 		fontSize: 14,
@@ -64,7 +64,7 @@ export function TextDiffView(props: TextDiffViewProps) {
 	};
 
 	return (
-		<DiffEditor
+		<MonacoDiffEditor
 			height="100%"
 			language={language}
 			original={originalContent}

--- a/studio-ui/ui/app/src/components/CompareVersionsDialog/VersionsDialogContext.tsx
+++ b/studio-ui/ui/app/src/components/CompareVersionsDialog/VersionsDialogContext.tsx
@@ -15,7 +15,7 @@
  */
 
 import { createContext, MutableRefObject, useContext } from 'react';
-import { DiffEditorProps } from '@monaco-editor/react';
+import { MonacoDiffEditorOptions } from '../MonacoEditor';
 import { CompareVersionsDialogProps } from './utils';
 import { ViewVersionDialogProps } from '../ViewVersionDialog/utils';
 import { LookupTable } from '../../models';
@@ -26,7 +26,7 @@ export interface FieldViewState {
 	cleanText: boolean;
 	compareMode: boolean;
 	compareModeDisabled: boolean;
-	monacoOptions: DiffEditorProps['options'];
+	monacoOptions: MonacoDiffEditorOptions;
 }
 
 export interface VersionsDialogContextProps {
@@ -45,8 +45,8 @@ export const initialFieldViewState = {
 	monacoOptions: {
 		ignoreTrimWhitespace: false,
 		renderSideBySide: true,
-		diffWordWrap: 'off' as DiffEditorProps['options']['diffWordWrap'],
-		wordWrap: 'on' as DiffEditorProps['options']['wordWrap']
+		diffWordWrap: 'off' as MonacoDiffEditorOptions['diffWordWrap'],
+		wordWrap: 'on' as MonacoDiffEditorOptions['wordWrap']
 	}
 };
 
@@ -63,7 +63,7 @@ export interface VersionsDialogContextApi {
 	setCompareSlideOutState: (props: Partial<CompareVersionsDialogProps>) => void;
 	setViewSlideOutState: (props: Partial<ViewVersionDialogProps>) => void;
 	setFieldViewState: (fieldId: string, viewState: Partial<FieldViewState>) => void;
-	setFieldViewEditorOptionsState: (fieldId: string, options: DiffEditorProps['options']) => void;
+	setFieldViewEditorOptionsState: (fieldId: string, options: MonacoDiffEditorOptions) => void;
 	closeSlideOuts: () => void;
 }
 

--- a/studio-ui/ui/app/src/components/ConflictedPathDiffDialog/ConflictedPathDiffDialogSplitView.tsx
+++ b/studio-ui/ui/app/src/components/ConflictedPathDiffDialog/ConflictedPathDiffDialogSplitView.tsx
@@ -14,13 +14,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { FileDiff } from '../../models/Repository';
-import { withMonaco } from '../../utils/system';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material';
-import Box from '@mui/material/Box';
+import { MonacoDiffEditor } from '../MonacoEditor';
 
 export interface SplitViewProps {
 	diff: FileDiff;
@@ -30,37 +29,26 @@ export interface SplitViewProps {
 
 export function ConflictedPathDiffDialogSplitView(props: SplitViewProps) {
 	const { diff, className, sx } = props;
-	const ref = useRef<HTMLDivElement>(undefined);
 	const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-	const diffEditorRef = useRef(null);
-	useEffect(() => {
-		if (diff) {
-			withMonaco((monaco) => {
-				const studioVersion = monaco.editor.createModel(diff.studioVersion, 'text/plain');
-				const remoteVersion = monaco.editor.createModel(diff.remoteVersion, 'text/plain');
-				monaco.editor.setTheme(prefersDarkMode ? 'vs-dark' : 'vs');
-				// Only create diff editor if it doesn't exist yet.
-				// This is to avoid creating a new diff editor on every update.
-				if (!diffEditorRef.current) {
-					diffEditorRef.current = monaco.editor.createDiffEditor(ref.current, {
-						scrollbar: {
-							alwaysConsumeMouseWheel: false
-						},
-						readOnly: true,
-						// Monaco editor has a breakpoint for split view, we had to decrease it for the split view to show in current dialog
-						renderSideBySideInlineBreakpoint: 300,
-						automaticLayout: true
-					});
-				}
-				diffEditorRef.current.setModel({
-					original: studioVersion,
-					modified: remoteVersion
-				});
-			});
-		}
-	}, [diff, prefersDarkMode]);
 
-	return <Box ref={ref} className={className} sx={sx} />;
+	return (
+		<MonacoDiffEditor
+			className={className}
+			sx={sx}
+			height="100%"
+			language="plaintext"
+			original={diff?.studioVersion ?? ''}
+			modified={diff?.remoteVersion ?? ''}
+			theme={prefersDarkMode ? 'vs-dark' : 'vs'}
+			options={{
+				readOnly: true,
+				automaticLayout: true,
+				scrollbar: { alwaysConsumeMouseWheel: false },
+				// Monaco editor has a breakpoint for split view; decrease it for the current dialog
+				renderSideBySideInlineBreakpoint: 300
+			}}
+		/>
+	);
 }
 
 export default ConflictedPathDiffDialogSplitView;

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/XmlDiffDialog.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/XmlDiffDialog.tsx
@@ -16,7 +16,7 @@
 
 import { EnhancedDialog, EnhancedDialogProps } from '../../EnhancedDialog';
 import { DialogBody } from '../../DialogBody';
-import { DiffEditor } from '@monaco-editor/react';
+import { MonacoDiffEditor } from '../../MonacoEditor';
 import React from 'react';
 import useIsDarkModeTheme from '../../../hooks/useIsDarkModeTheme';
 
@@ -32,12 +32,12 @@ export function XmlDiffDialogBody(props: XmlDiffDialogProps) {
 		initialXml &&
 		currentXml && (
 			<DialogBody>
-				<DiffEditor
+				<MonacoDiffEditor
 					height="90vh"
 					language="xml"
 					original={initialXml}
 					modified={currentXml}
-					theme={isDark ? 'vs-dark' : 'light'}
+					theme={isDark ? 'vs-dark' : 'vs'}
 					options={{ readOnly: true, scrollBeyondLastLine: false }}
 				/>
 			</DialogBody>

--- a/studio-ui/ui/app/src/components/ContentTypeManagement/components/XmlViewerDialog.tsx
+++ b/studio-ui/ui/app/src/components/ContentTypeManagement/components/XmlViewerDialog.tsx
@@ -16,7 +16,7 @@
 
 import { EnhancedDialog, EnhancedDialogProps } from '../../EnhancedDialog';
 import { DialogBody } from '../../DialogBody';
-import Editor from '@monaco-editor/react';
+import { MonacoEditor } from '../../MonacoEditor';
 import React from 'react';
 import useIsDarkModeTheme from '../../../hooks/useIsDarkModeTheme';
 
@@ -30,11 +30,11 @@ export function XmlViewerDialogBody(props: XmlViewerDialogProps) {
 	return (
 		xml && (
 			<DialogBody>
-				<Editor
+				<MonacoEditor
 					height="90vh"
 					defaultLanguage="xml"
 					value={xml}
-					theme={isDark ? 'vs-dark' : 'light'}
+					theme={isDark ? 'vs-dark' : 'vs'}
 					options={{ readOnly: true, scrollBeyondLastLine: false }}
 				/>
 			</DialogBody>

--- a/studio-ui/ui/app/src/components/MonacoEditor/MonacoDiffEditor.tsx
+++ b/studio-ui/ui/app/src/components/MonacoEditor/MonacoDiffEditor.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import { SxProps } from '@mui/system';
+import { Theme } from '@mui/material';
+import { withMonaco } from '../../utils/system';
+import type Monaco from '../../models/Monaco';
+import { MonacoDiffEditorOptions, normalizeMonacoTheme } from './types';
+
+export interface MonacoDiffEditorProps {
+	height?: string | number;
+	language?: string;
+	original?: string;
+	modified?: string;
+	theme?: string;
+	options?: MonacoDiffEditorOptions;
+	className?: string;
+	sx?: SxProps<Theme>;
+}
+
+export function MonacoDiffEditor(props: MonacoDiffEditorProps) {
+	const {
+		height = '100%',
+		language = 'plaintext',
+		original = '',
+		modified = '',
+		theme = 'vs',
+		options,
+		className,
+		sx
+	} = props;
+	const containerRef = useRef<HTMLDivElement>(undefined);
+	const editorRef = useRef<ReturnType<Monaco['editor']['createDiffEditor']>>(null);
+	const monacoRef = useRef<Monaco>(null);
+	const originalModelRef = useRef<ReturnType<Monaco['editor']['createModel']>>(null);
+	const modifiedModelRef = useRef<ReturnType<Monaco['editor']['createModel']>>(null);
+	const propsRef = useRef(props);
+	const [ready, setReady] = useState(false);
+
+	useEffect(() => {
+		propsRef.current = props;
+	});
+
+	useEffect(() => {
+		let active = true;
+		withMonaco((monaco) => {
+			if (!active || !containerRef.current || editorRef.current) {
+				return;
+			}
+			const {
+				original: currentOriginal = '',
+				modified: currentModified = '',
+				language: currentLanguage = 'plaintext',
+				theme: currentTheme = 'vs',
+				options: currentOptions
+			} = propsRef.current;
+			monacoRef.current = monaco;
+			monaco.editor.setTheme(normalizeMonacoTheme(currentTheme));
+			const originalModel = monaco.editor.createModel(currentOriginal, currentLanguage);
+			const modifiedModel = monaco.editor.createModel(currentModified, currentLanguage);
+			originalModelRef.current = originalModel;
+			modifiedModelRef.current = modifiedModel;
+			editorRef.current = monaco.editor.createDiffEditor(containerRef.current, {
+				automaticLayout: true,
+				...currentOptions
+			});
+			editorRef.current.setModel({
+				original: originalModel,
+				modified: modifiedModel
+			});
+			setReady(true);
+		});
+		return () => {
+			active = false;
+			editorRef.current?.dispose();
+			editorRef.current = null;
+			originalModelRef.current?.dispose();
+			originalModelRef.current = null;
+			modifiedModelRef.current?.dispose();
+			modifiedModelRef.current = null;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!ready) {
+			return;
+		}
+		const monaco = monacoRef.current;
+		const originalModel = originalModelRef.current;
+		const modifiedModel = modifiedModelRef.current;
+		if (!monaco || !originalModel || !modifiedModel) {
+			return;
+		}
+		if (originalModel.getValue() !== original) {
+			originalModel.setValue(original ?? '');
+		}
+		if (modifiedModel.getValue() !== modified) {
+			modifiedModel.setValue(modified ?? '');
+		}
+		monaco.editor.setModelLanguage(originalModel, language);
+		monaco.editor.setModelLanguage(modifiedModel, language);
+	}, [ready, original, modified, language]);
+
+	useEffect(() => {
+		if (!ready) {
+			return;
+		}
+		editorRef.current?.updateOptions(options ?? {});
+	}, [ready, options]);
+
+	useEffect(() => {
+		if (!ready) {
+			return;
+		}
+		monacoRef.current?.editor.setTheme(normalizeMonacoTheme(theme));
+	}, [ready, theme]);
+
+	return (
+		<Box
+			ref={containerRef}
+			className={className}
+			sx={{
+				height,
+				width: '100%',
+				...((sx as object) ?? {})
+			}}
+		/>
+	);
+}
+
+export default MonacoDiffEditor;

--- a/studio-ui/ui/app/src/components/MonacoEditor/MonacoDiffEditor.tsx
+++ b/studio-ui/ui/app/src/components/MonacoEditor/MonacoDiffEditor.tsx
@@ -14,13 +14,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useMemo } from 'react';
 import Box from '@mui/material/Box';
 import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material';
-import { withMonaco } from '../../utils/system';
 import type Monaco from '../../models/Monaco';
-import { MonacoDiffEditorOptions, normalizeMonacoTheme } from './types';
+import { MonacoDiffEditorOptions } from './types';
+import { useMonacoLifecycle } from './useMonacoLifecycle';
 
 export interface MonacoDiffEditorProps {
 	height?: string | number;
@@ -31,6 +31,23 @@ export interface MonacoDiffEditorProps {
 	options?: MonacoDiffEditorOptions;
 	className?: string;
 	sx?: SxProps<Theme>;
+}
+
+function createDiffEditor(
+	monaco: Monaco,
+	container: HTMLDivElement,
+	models: ReturnType<Monaco['editor']['createModel']>[],
+	options?: MonacoDiffEditorOptions
+) {
+	const editor = monaco.editor.createDiffEditor(container, {
+		automaticLayout: true,
+		...options
+	});
+	editor.setModel({
+		original: models[0],
+		modified: models[1]
+	});
+	return editor;
 }
 
 export function MonacoDiffEditor(props: MonacoDiffEditorProps) {
@@ -44,91 +61,14 @@ export function MonacoDiffEditor(props: MonacoDiffEditorProps) {
 		className,
 		sx
 	} = props;
-	const containerRef = useRef<HTMLDivElement>(undefined);
-	const editorRef = useRef<ReturnType<Monaco['editor']['createDiffEditor']>>(null);
-	const monacoRef = useRef<Monaco>(null);
-	const originalModelRef = useRef<ReturnType<Monaco['editor']['createModel']>>(null);
-	const modifiedModelRef = useRef<ReturnType<Monaco['editor']['createModel']>>(null);
-	const propsRef = useRef(props);
-	const [ready, setReady] = useState(false);
-
-	useEffect(() => {
-		propsRef.current = props;
-	});
-
-	useEffect(() => {
-		let active = true;
-		withMonaco((monaco) => {
-			if (!active || !containerRef.current || editorRef.current) {
-				return;
-			}
-			const {
-				original: currentOriginal = '',
-				modified: currentModified = '',
-				language: currentLanguage = 'plaintext',
-				theme: currentTheme = 'vs',
-				options: currentOptions
-			} = propsRef.current;
-			monacoRef.current = monaco;
-			monaco.editor.setTheme(normalizeMonacoTheme(currentTheme));
-			const originalModel = monaco.editor.createModel(currentOriginal, currentLanguage);
-			const modifiedModel = monaco.editor.createModel(currentModified, currentLanguage);
-			originalModelRef.current = originalModel;
-			modifiedModelRef.current = modifiedModel;
-			editorRef.current = monaco.editor.createDiffEditor(containerRef.current, {
-				automaticLayout: true,
-				...currentOptions
-			});
-			editorRef.current.setModel({
-				original: originalModel,
-				modified: modifiedModel
-			});
-			setReady(true);
-		});
-		return () => {
-			active = false;
-			editorRef.current?.dispose();
-			editorRef.current = null;
-			originalModelRef.current?.dispose();
-			originalModelRef.current = null;
-			modifiedModelRef.current?.dispose();
-			modifiedModelRef.current = null;
-		};
-	}, []);
-
-	useEffect(() => {
-		if (!ready) {
-			return;
-		}
-		const monaco = monacoRef.current;
-		const originalModel = originalModelRef.current;
-		const modifiedModel = modifiedModelRef.current;
-		if (!monaco || !originalModel || !modifiedModel) {
-			return;
-		}
-		if (originalModel.getValue() !== original) {
-			originalModel.setValue(original ?? '');
-		}
-		if (modifiedModel.getValue() !== modified) {
-			modifiedModel.setValue(modified ?? '');
-		}
-		monaco.editor.setModelLanguage(originalModel, language);
-		monaco.editor.setModelLanguage(modifiedModel, language);
-	}, [ready, original, modified, language]);
-
-	useEffect(() => {
-		if (!ready) {
-			return;
-		}
-		editorRef.current?.updateOptions(options ?? {});
-	}, [ready, options]);
-
-	useEffect(() => {
-		if (!ready) {
-			return;
-		}
-		monacoRef.current?.editor.setTheme(normalizeMonacoTheme(theme));
-	}, [ready, theme]);
+	const models = useMemo(
+		() => [
+			{ value: original, language },
+			{ value: modified, language }
+		],
+		[original, modified, language]
+	);
+	const containerRef = useMonacoLifecycle({ models, theme, options, createEditor: createDiffEditor });
 
 	return (
 		<Box

--- a/studio-ui/ui/app/src/components/MonacoEditor/MonacoEditor.tsx
+++ b/studio-ui/ui/app/src/components/MonacoEditor/MonacoEditor.tsx
@@ -21,6 +21,7 @@ import { Theme } from '@mui/material';
 import type Monaco from '../../models/Monaco';
 import { MonacoEditorOptions } from './types';
 import { useMonacoLifecycle } from './useMonacoLifecycle';
+import { consolidateSx } from '../../utils/system';
 
 export interface MonacoEditorProps {
 	height?: string | number;
@@ -52,17 +53,7 @@ export function MonacoEditor(props: MonacoEditorProps) {
 	const models = useMemo(() => [{ value, language: resolvedLanguage }], [value, resolvedLanguage]);
 	const containerRef = useMonacoLifecycle({ models, theme, options, createEditor });
 
-	return (
-		<Box
-			ref={containerRef}
-			className={className}
-			sx={{
-				height,
-				width: '100%',
-				...((sx as object) ?? {})
-			}}
-		/>
-	);
+	return <Box ref={containerRef} className={className} sx={consolidateSx({ height, width: '100%' }, sx)} />;
 }
 
 export default MonacoEditor;

--- a/studio-ui/ui/app/src/components/MonacoEditor/MonacoEditor.tsx
+++ b/studio-ui/ui/app/src/components/MonacoEditor/MonacoEditor.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import { SxProps } from '@mui/system';
+import { Theme } from '@mui/material';
+import { withMonaco } from '../../utils/system';
+import type Monaco from '../../models/Monaco';
+import { MonacoEditorOptions, normalizeMonacoTheme } from './types';
+
+export interface MonacoEditorProps {
+	height?: string | number;
+	language?: string;
+	defaultLanguage?: string;
+	value?: string;
+	theme?: string;
+	options?: MonacoEditorOptions;
+	className?: string;
+	sx?: SxProps<Theme>;
+}
+
+export function MonacoEditor(props: MonacoEditorProps) {
+	const { height = '100%', language, defaultLanguage, value = '', theme = 'vs', options, className, sx } = props;
+	const resolvedLanguage = language || defaultLanguage || 'plaintext';
+	const containerRef = useRef<HTMLDivElement>(undefined);
+	const editorRef = useRef<ReturnType<Monaco['editor']['create']>>(null);
+	const monacoRef = useRef<Monaco>(null);
+	const modelRef = useRef<ReturnType<Monaco['editor']['createModel']>>(null);
+	const propsRef = useRef(props);
+	const [ready, setReady] = useState(false);
+
+	useEffect(() => {
+		propsRef.current = props;
+	});
+
+	useEffect(() => {
+		let active = true;
+		withMonaco((monaco) => {
+			if (!active || !containerRef.current || editorRef.current) {
+				return;
+			}
+			const {
+				value: currentValue = '',
+				language: currentLanguage,
+				defaultLanguage: currentDefaultLanguage,
+				theme: currentTheme = 'vs',
+				options: currentOptions
+			} = propsRef.current;
+			const lang = currentLanguage || currentDefaultLanguage || 'plaintext';
+			monacoRef.current = monaco;
+			monaco.editor.setTheme(normalizeMonacoTheme(currentTheme));
+			const model = monaco.editor.createModel(currentValue, lang);
+			modelRef.current = model;
+			editorRef.current = monaco.editor.create(containerRef.current, {
+				model,
+				automaticLayout: true,
+				...currentOptions
+			});
+			setReady(true);
+		});
+		return () => {
+			active = false;
+			editorRef.current?.dispose();
+			editorRef.current = null;
+			modelRef.current?.dispose();
+			modelRef.current = null;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!ready) {
+			return;
+		}
+		const model = modelRef.current;
+		const monaco = monacoRef.current;
+		if (!model || !monaco) {
+			return;
+		}
+		if (model.getValue() !== value) {
+			model.setValue(value ?? '');
+		}
+		monaco.editor.setModelLanguage(model, resolvedLanguage);
+	}, [ready, value, resolvedLanguage]);
+
+	useEffect(() => {
+		if (!ready) {
+			return;
+		}
+		editorRef.current?.updateOptions(options ?? {});
+	}, [ready, options]);
+
+	useEffect(() => {
+		if (!ready) {
+			return;
+		}
+		monacoRef.current?.editor.setTheme(normalizeMonacoTheme(theme));
+	}, [ready, theme]);
+
+	return (
+		<Box
+			ref={containerRef}
+			className={className}
+			sx={{
+				height,
+				width: '100%',
+				...((sx as object) ?? {})
+			}}
+		/>
+	);
+}
+
+export default MonacoEditor;

--- a/studio-ui/ui/app/src/components/MonacoEditor/MonacoEditor.tsx
+++ b/studio-ui/ui/app/src/components/MonacoEditor/MonacoEditor.tsx
@@ -14,13 +14,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useMemo } from 'react';
 import Box from '@mui/material/Box';
 import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material';
-import { withMonaco } from '../../utils/system';
 import type Monaco from '../../models/Monaco';
-import { MonacoEditorOptions, normalizeMonacoTheme } from './types';
+import { MonacoEditorOptions } from './types';
+import { useMonacoLifecycle } from './useMonacoLifecycle';
 
 export interface MonacoEditorProps {
 	height?: string | number;
@@ -33,82 +33,24 @@ export interface MonacoEditorProps {
 	sx?: SxProps<Theme>;
 }
 
+function createEditor(
+	monaco: Monaco,
+	container: HTMLDivElement,
+	models: ReturnType<Monaco['editor']['createModel']>[],
+	options?: MonacoEditorOptions
+) {
+	return monaco.editor.create(container, {
+		model: models[0],
+		automaticLayout: true,
+		...options
+	});
+}
+
 export function MonacoEditor(props: MonacoEditorProps) {
 	const { height = '100%', language, defaultLanguage, value = '', theme = 'vs', options, className, sx } = props;
 	const resolvedLanguage = language || defaultLanguage || 'plaintext';
-	const containerRef = useRef<HTMLDivElement>(undefined);
-	const editorRef = useRef<ReturnType<Monaco['editor']['create']>>(null);
-	const monacoRef = useRef<Monaco>(null);
-	const modelRef = useRef<ReturnType<Monaco['editor']['createModel']>>(null);
-	const propsRef = useRef(props);
-	const [ready, setReady] = useState(false);
-
-	useEffect(() => {
-		propsRef.current = props;
-	});
-
-	useEffect(() => {
-		let active = true;
-		withMonaco((monaco) => {
-			if (!active || !containerRef.current || editorRef.current) {
-				return;
-			}
-			const {
-				value: currentValue = '',
-				language: currentLanguage,
-				defaultLanguage: currentDefaultLanguage,
-				theme: currentTheme = 'vs',
-				options: currentOptions
-			} = propsRef.current;
-			const lang = currentLanguage || currentDefaultLanguage || 'plaintext';
-			monacoRef.current = monaco;
-			monaco.editor.setTheme(normalizeMonacoTheme(currentTheme));
-			const model = monaco.editor.createModel(currentValue, lang);
-			modelRef.current = model;
-			editorRef.current = monaco.editor.create(containerRef.current, {
-				model,
-				automaticLayout: true,
-				...currentOptions
-			});
-			setReady(true);
-		});
-		return () => {
-			active = false;
-			editorRef.current?.dispose();
-			editorRef.current = null;
-			modelRef.current?.dispose();
-			modelRef.current = null;
-		};
-	}, []);
-
-	useEffect(() => {
-		if (!ready) {
-			return;
-		}
-		const model = modelRef.current;
-		const monaco = monacoRef.current;
-		if (!model || !monaco) {
-			return;
-		}
-		if (model.getValue() !== value) {
-			model.setValue(value ?? '');
-		}
-		monaco.editor.setModelLanguage(model, resolvedLanguage);
-	}, [ready, value, resolvedLanguage]);
-
-	useEffect(() => {
-		if (!ready) {
-			return;
-		}
-		editorRef.current?.updateOptions(options ?? {});
-	}, [ready, options]);
-
-	useEffect(() => {
-		if (!ready) {
-			return;
-		}
-		monacoRef.current?.editor.setTheme(normalizeMonacoTheme(theme));
-	}, [ready, theme]);
+	const models = useMemo(() => [{ value, language: resolvedLanguage }], [value, resolvedLanguage]);
+	const containerRef = useMonacoLifecycle({ models, theme, options, createEditor });
 
 	return (
 		<Box

--- a/studio-ui/ui/app/src/components/MonacoEditor/index.ts
+++ b/studio-ui/ui/app/src/components/MonacoEditor/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { default, MonacoEditor } from './MonacoEditor';
+export type { MonacoEditorProps } from './MonacoEditor';
+
+export { MonacoDiffEditor } from './MonacoDiffEditor';
+export type { MonacoDiffEditorProps } from './MonacoDiffEditor';
+
+export type { MonacoEditorOptions, MonacoDiffEditorOptions } from './types';
+export { normalizeMonacoTheme } from './types';

--- a/studio-ui/ui/app/src/components/MonacoEditor/types.ts
+++ b/studio-ui/ui/app/src/components/MonacoEditor/types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type Monaco from '../../models/Monaco';
+
+export type MonacoEditorOptions = NonNullable<Parameters<Monaco['editor']['create']>[1]>;
+export type MonacoDiffEditorOptions = NonNullable<Parameters<Monaco['editor']['createDiffEditor']>[1]>;
+
+/** Monaco's built-in themes; `@monaco-editor/react` used `"light"` as an alias for `"vs"`. */
+export function normalizeMonacoTheme(theme?: string): string {
+	if (!theme || theme === 'light') {
+		return 'vs';
+	}
+	return theme;
+}

--- a/studio-ui/ui/app/src/components/MonacoEditor/useMonacoLifecycle.ts
+++ b/studio-ui/ui/app/src/components/MonacoEditor/useMonacoLifecycle.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { withMonaco } from '../../utils/system';
+import type Monaco from '../../models/Monaco';
+import { normalizeMonacoTheme } from './types';
+
+type MonacoModel = ReturnType<Monaco['editor']['createModel']>;
+
+interface MonacoModelDefinition {
+	value: string;
+	language: string;
+}
+
+interface MonacoEditorInstance<TOptions> {
+	dispose(): void;
+	updateOptions(options: TOptions): void;
+}
+
+interface UseMonacoLifecycleOptions<TEditor extends MonacoEditorInstance<TOptions>, TOptions> {
+	models: MonacoModelDefinition[];
+	theme: string;
+	options?: TOptions;
+	createEditor(monaco: Monaco, container: HTMLDivElement, models: MonacoModel[], options?: TOptions): TEditor;
+}
+
+export function useMonacoLifecycle<TEditor extends MonacoEditorInstance<TOptions>, TOptions>({
+	models,
+	theme,
+	options,
+	createEditor
+}: UseMonacoLifecycleOptions<TEditor, TOptions>) {
+	const containerRef = useRef<HTMLDivElement>(undefined);
+	const editorRef = useRef<TEditor>(null);
+	const monacoRef = useRef<Monaco>(null);
+	const modelRefs = useRef<MonacoModel[]>([]);
+	const lifecycleOptionsRef = useRef({ models, theme, options, createEditor });
+	const [ready, setReady] = useState(false);
+
+	useEffect(() => {
+		lifecycleOptionsRef.current = { models, theme, options, createEditor };
+	});
+
+	useEffect(() => {
+		let active = true;
+		withMonaco((monaco) => {
+			if (!active || !containerRef.current || editorRef.current) {
+				return;
+			}
+			const current = lifecycleOptionsRef.current;
+			monacoRef.current = monaco;
+			monaco.editor.setTheme(normalizeMonacoTheme(current.theme));
+			const editorModels = current.models.map(({ value, language }) => monaco.editor.createModel(value, language));
+			modelRefs.current = editorModels;
+			editorRef.current = current.createEditor(monaco, containerRef.current, editorModels, current.options);
+			setReady(true);
+		});
+		return () => {
+			active = false;
+			editorRef.current?.dispose();
+			editorRef.current = null;
+			modelRefs.current.forEach((model) => model.dispose());
+			modelRefs.current = [];
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!ready || !monacoRef.current) {
+			return;
+		}
+		modelRefs.current.forEach((model, index) => {
+			const definition = models[index];
+			if (!definition) {
+				return;
+			}
+			if (model.getValue() !== definition.value) {
+				model.setValue(definition.value);
+			}
+			monacoRef.current.editor.setModelLanguage(model, definition.language);
+		});
+	}, [ready, models]);
+
+	useEffect(() => {
+		if (ready) {
+			editorRef.current?.updateOptions(options ?? ({} as TOptions));
+		}
+	}, [ready, options]);
+
+	useEffect(() => {
+		if (ready) {
+			monacoRef.current?.editor.setTheme(normalizeMonacoTheme(theme));
+		}
+	}, [ready, theme]);
+
+	return containerRef;
+}

--- a/studio-ui/ui/app/src/components/ViewVersionDialog/ContentFieldView.tsx
+++ b/studio-ui/ui/app/src/components/ViewVersionDialog/ContentFieldView.tsx
@@ -34,7 +34,7 @@ import Typography from '@mui/material/Typography';
 import { FormattedMessage } from 'react-intl';
 import CheckboxGroupView from './FieldTypesViews/CheckboxGroupView';
 import TextView from './FieldTypesViews/TextView';
-import { EditorProps } from '@monaco-editor/react';
+import { MonacoEditorProps } from '../MonacoEditor';
 import { ViewComponentBaseProps } from './utils';
 import { getContentInstanceXmlValueFromProp } from '../../utils/content';
 import FileNameView from './FieldTypesViews/FileNameView';
@@ -50,7 +50,7 @@ export interface ContentFieldViewProps {
 }
 
 export interface ViewComponentProps extends Pick<ViewComponentBaseProps, 'xml' | 'field'> {
-	editorProps?: EditorProps;
+	editorProps?: MonacoEditorProps;
 }
 
 export const typesViewMap = {

--- a/studio-ui/ui/app/src/components/ViewVersionDialog/FieldTypesViews/FileNameView.tsx
+++ b/studio-ui/ui/app/src/components/ViewVersionDialog/FieldTypesViews/FileNameView.tsx
@@ -16,14 +16,14 @@
 
 import React from 'react';
 import { ViewComponentBaseProps } from '../utils';
-import { EditorProps } from '@monaco-editor/react';
+import { MonacoEditorProps } from '../../MonacoEditor';
 import { fromString } from '../../../utils/xml';
 import { getContentFileNameFromPath } from '../../../utils/content';
 import TextView from './TextView';
 import { XmlKeys } from '../../FormsEngine/lib/formConsts';
 
 export interface FileNameViewProps extends Pick<ViewComponentBaseProps, 'xml'> {
-	editorProps?: EditorProps;
+	editorProps?: MonacoEditorProps;
 }
 
 export function FileNameView(props: FileNameViewProps) {

--- a/studio-ui/ui/app/src/components/ViewVersionDialog/FieldTypesViews/TextView.tsx
+++ b/studio-ui/ui/app/src/components/ViewVersionDialog/FieldTypesViews/TextView.tsx
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Editor, { EditorProps } from '@monaco-editor/react';
+import { MonacoEditor, MonacoEditorProps } from '../../MonacoEditor';
 import React from 'react';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useVersionsDialogContext } from '../../CompareVersionsDialog/VersionsDialogContext';
@@ -26,7 +26,7 @@ import { XmlKeys } from '../../FormsEngine/lib/formConsts';
 
 export interface TextViewProps extends Pick<ViewComponentBaseProps, 'xml'> {
 	field?: ContentTypeField;
-	editorProps?: EditorProps;
+	editorProps?: MonacoEditorProps;
 }
 
 export function TextView(props: TextViewProps) {
@@ -38,7 +38,7 @@ export function TextView(props: TextViewProps) {
 	const value = cleanText ? removeTags(content ?? '') : content;
 	const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 	const language = textViewLanguageMap[field?.type] || 'xml';
-	const monacoOptions: EditorProps['options'] = {
+	const monacoOptions: MonacoEditorProps['options'] = {
 		readOnly: true,
 		automaticLayout: true,
 		fontSize: 14,
@@ -50,12 +50,12 @@ export function TextView(props: TextViewProps) {
 	};
 
 	return (
-		<Editor
+		<MonacoEditor
 			height="100%"
 			language={language}
 			value={value}
 			theme={prefersDarkMode ? 'vs-dark' : 'vs'}
-			{...(editorProps as EditorProps)}
+			{...editorProps}
 			options={monacoOptions}
 		/>
 	);

--- a/studio-ui/ui/app/src/components/ViewVersionDialog/ViewVersionDialog.tsx
+++ b/studio-ui/ui/app/src/components/ViewVersionDialog/ViewVersionDialog.tsx
@@ -35,7 +35,7 @@ import {
 	VersionsDialogContextProps,
 	VersionsDialogContextType
 } from '../CompareVersionsDialog/VersionsDialogContext';
-import { DiffEditorProps } from '@monaco-editor/react';
+import { MonacoDiffEditorOptions } from '../MonacoEditor';
 import { getDialogHeaderActions } from '../CompareVersionsDialog';
 
 export function ViewVersionDialog(props: ViewVersionDialogProps) {
@@ -62,7 +62,7 @@ export function ViewVersionDialog(props: ViewVersionDialogProps) {
 					fieldsViewState: { ...state.fieldsViewState, [fieldId]: { ...state.fieldsViewState[fieldId], ...viewState } }
 				});
 			},
-			setFieldViewEditorOptionsState(fieldId: string, options: DiffEditorProps['options']) {
+			setFieldViewEditorOptionsState(fieldId: string, options: MonacoDiffEditorOptions) {
 				setState({
 					...state,
 					fieldsViewState: {

--- a/studio-ui/yarn.lock
+++ b/studio-ui/yarn.lock
@@ -1666,7 +1666,6 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@formatjs/cli": "npm:^6.13.1"
     "@graphiql/plugin-explorer": "npm:^5.1.1"
-    "@monaco-editor/react": "npm:^4.7.0"
     "@mui/icons-material": "npm:^7.3.9"
     "@mui/lab": "npm:7.0.1-beta.23"
     "@mui/material": "npm:^7.3.9"
@@ -2658,28 +2657,6 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10/f9fabe1122058f4fedc242bdc43fcaacb6b222c6fb712b7904c37704dcb16e50e07ca137ff99043da44292b18a8720296ff97f7703e960678b8ef51d0db4d250
-  languageName: node
-  linkType: hard
-
-"@monaco-editor/loader@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@monaco-editor/loader@npm:1.5.0"
-  dependencies:
-    state-local: "npm:^1.0.6"
-  checksum: 10/97d79916afa856809de4eaafaee1b1c6dc9443c0fdde81a7562f4ffa0c252496e97c4becf4c1f00c4119878c76d73390ce416a64305e59865a5830bded5afe55
-  languageName: node
-  linkType: hard
-
-"@monaco-editor/react@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "@monaco-editor/react@npm:4.7.0"
-  dependencies:
-    "@monaco-editor/loader": "npm:^1.5.0"
-  peerDependencies:
-    monaco-editor: ">= 0.25.0 < 1"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/d72392c4ed6faf8d830ba43421461e1b767b5978edba0739457d7781aa9533c66982be7f59bb156a77a2b578eddfb4711f50e0d84f0f0d25d28b5ab11140f5cc
   languageName: node
   linkType: hard
 
@@ -13231,13 +13208,6 @@ __metadata:
   version: 0.1.8
   resolution: "stable@npm:0.1.8"
   checksum: 10/2ff482bb100285d16dd75cd8f7c60ab652570e8952c0bfa91828a2b5f646a0ff533f14596ea4eabd48bb7f4aeea408dce8f8515812b975d958a4cc4fa6b9dfeb
-  languageName: node
-  linkType: hard
-
-"state-local@npm:^1.0.6":
-  version: 1.0.7
-  resolution: "state-local@npm:1.0.7"
-  checksum: 10/1d956043e270861d40a639ff3457938cf61dbc7e25209d21b55060d8dfaf74742b8a1e525ed6fcb0c2d89b7d3e305bb8589bf27392012889456b3ad82a4b7d0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removed `@monaco-editor/react` outdated library and created components to use in studio (the same way we're using it in `ConflictedPathDiffDialogSplitView.tsx`.

https://github.com/craftersoftware/craftercms/issues/8854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added reusable text and diff editors across version, XML, and conflict dialogs.
- Editors support configurable themes, languages, dimensions, styling, and display options.

## Improvements
- Standardized editor behavior across viewing, comparison, and conflict workflows.
- Improved light-theme consistency across editor and diff views.
- Enhanced content synchronization, automatic layout, and resource cleanup for smoother experiences.
- Improved consistency and reliability when displaying and comparing content across dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->