### PR TITLE
Separate global role-permission mappings from site mappings

### DIFF
--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/PermissionMappingsProviderImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/PermissionMappingsProviderImpl.java
@@ -84,32 +84,47 @@ public class PermissionMappingsProviderImpl implements PermissionMappingsProvide
 		return mappings;
 	}
 
+	private SitePermissionMappingsImpl getGlobalPermissionMappings() throws ServiceLayerException {
+		var cacheKey = CONFIGURATION_GLOBAL_SYSTEM_SITE + CACHE_KEY;
+		SitePermissionMappingsImpl mappings = cache.getIfPresent(cacheKey);
+		if (mappings == null) {
+			logger.debug("Cache miss for global permission mappings cache key '{}'", cacheKey);
+			mappings = fetchGlobalPermissionMappings();
+			cache.put(cacheKey, mappings);
+		}
+		return mappings;
+	}
+
+	private SitePermissionMappingsImpl fetchGlobalPermissionMappings() throws ServiceLayerException {
+		SitePermissionMappingsImpl globalPermissionMappings = new SitePermissionMappingsImpl(true);
+		String globalRolesConfigPath = studioConfiguration.getProperty(CONFIGURATION_GLOBAL_CONFIG_BASE_PATH) +
+				FILE_SEPARATOR + studioConfiguration.getProperty(CONFIGURATION_GLOBAL_ROLE_MAPPINGS_FILE_NAME);
+		Document globalRoleMappingsDocument = configurationService
+				.getGlobalConfigurationAsDocument(globalRolesConfigPath);
+
+		String globalPermissionsConfigPath = studioConfiguration.getProperty(CONFIGURATION_GLOBAL_CONFIG_BASE_PATH)
+				+ FILE_SEPARATOR +
+				studioConfiguration.getProperty(CONFIGURATION_GLOBAL_PERMISSION_MAPPINGS_FILE_NAME);
+		Document globalPermissionMappingsDocument = configurationService
+				.getGlobalConfigurationAsDocument(globalPermissionsConfigPath);
+
+		loadRoles(globalRoleMappingsDocument, globalPermissionMappings);
+		loadPermissions(globalPermissionMappingsDocument, globalPermissionMappings);
+		return globalPermissionMappings;
+	}
+
 	private SitePermissionMappingsImpl fetchSitePermissionMappings(String site) throws ServiceLayerException {
-		SitePermissionMappingsImpl sitePermissionMappings = new SitePermissionMappingsImpl();
+		SitePermissionMappingsImpl sitePermissionMappings = new SitePermissionMappingsImpl(getGlobalPermissionMappings());
 
 		if (isNotEmpty(site) && !CS.equals(site, studioConfiguration.getProperty(CONFIGURATION_GLOBAL_SYSTEM_SITE))) {
 			Document roleMappingsDocument = configurationService.getConfigurationAsDocument(site, MODULE_STUDIO,
-				studioConfiguration.getProperty(CONFIGURATION_SITE_ROLE_MAPPINGS_FILE_NAME),
-				studioConfiguration.getProperty(CONFIGURATION_ENVIRONMENT_ACTIVE));
+					studioConfiguration.getProperty(CONFIGURATION_SITE_ROLE_MAPPINGS_FILE_NAME),
+					studioConfiguration.getProperty(CONFIGURATION_ENVIRONMENT_ACTIVE));
 			Document permissionsMappingsDocument = configurationService.getConfigurationAsDocument(site, MODULE_STUDIO,
-				studioConfiguration.getProperty(CONFIGURATION_SITE_PERMISSION_MAPPINGS_FILE_NAME),
-				studioConfiguration.getProperty(CONFIGURATION_ENVIRONMENT_ACTIVE));
+					studioConfiguration.getProperty(CONFIGURATION_SITE_PERMISSION_MAPPINGS_FILE_NAME),
+					studioConfiguration.getProperty(CONFIGURATION_ENVIRONMENT_ACTIVE));
 			loadRoles(roleMappingsDocument, sitePermissionMappings);
 			loadPermissions(permissionsMappingsDocument, sitePermissionMappings);
-		} else {
-			String globalRolesConfigPath = studioConfiguration.getProperty(CONFIGURATION_GLOBAL_CONFIG_BASE_PATH) +
-					FILE_SEPARATOR + studioConfiguration.getProperty(CONFIGURATION_GLOBAL_ROLE_MAPPINGS_FILE_NAME);
-			Document globalRoleMappingsDocument = configurationService
-					.getGlobalConfigurationAsDocument(globalRolesConfigPath);
-
-			String globalPermissionsConfigPath = studioConfiguration.getProperty(CONFIGURATION_GLOBAL_CONFIG_BASE_PATH)
-					+ FILE_SEPARATOR +
-					studioConfiguration.getProperty(CONFIGURATION_GLOBAL_PERMISSION_MAPPINGS_FILE_NAME);
-			Document globalPermissionMappingsDocument = configurationService
-					.getGlobalConfigurationAsDocument(globalPermissionsConfigPath);
-
-			loadRoles(globalRoleMappingsDocument, sitePermissionMappings);
-			loadPermissions(globalPermissionMappingsDocument, sitePermissionMappings);
 		}
 		return sitePermissionMappings;
 	}

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImpl.java
@@ -43,8 +43,22 @@ import static org.craftercms.studio.permissions.StudioPermissionsConstants.PERMI
  */
 public class SitePermissionMappingsImpl implements SitePermissionMappings {
 
-	private final Map<NormalizedRole, RolePermissionMappingsImpl> rolePermissions = new HashMap<>();
-	private final Map<NormalizedGroup, List<NormalizedRole>> groupToRolesMapping = new HashMap<>();
+	private final Map<NormalizedRole, RolePermissionMappingsImpl> rolePermissions;
+	private final Map<NormalizedGroup, List<NormalizedRole>> groupToRolesMapping;
+	private final boolean isGlobal;
+	private SitePermissionMappingsImpl parent;
+
+	SitePermissionMappingsImpl(boolean isGlobal) {
+		this.rolePermissions = new HashMap<>();
+		this.groupToRolesMapping = new HashMap<>();
+		this.isGlobal = isGlobal;
+	}
+
+	SitePermissionMappingsImpl(SitePermissionMappingsImpl parent) {
+		// We call this for site level only
+		this(false);
+		this.parent = parent;
+	}
 
 	@Override
 	public long getAvailableActions(String username, List<Group> groups, String path) {
@@ -56,22 +70,34 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 				availableActions |= rolePermissionMappings.getActionsForPath(path);
 			}
 		}
+		if (parent != null) {
+			availableActions |= parent.getAvailableActions(username, groups, path);
+		}
 		return availableActions;
 	}
 
 	@Override
 	public long getSiteWideItemAvailableActions(String username, List<Group> groups) {
-		return mapSiteWidePermissionsToItemAvailableActions(getSiteWidePermissions(username, groups));
+		Set<String> permissions = new HashSet<>(getSiteWidePermissions(username, groups));
+		if (parent != null) {
+			permissions.addAll(parent.getSiteWidePermissions(username, groups));
+		}
+		return mapSiteWidePermissionsToItemAvailableActions(permissions);
 	}
 
 	@Override
 	public long getPublishPackageAvailableActions(String username, List<Group> groups) {
-		return mapSiteWidePermissionsToPackageAvailableActions(getSiteWidePermissions(username, groups));
+		Set<String> permissions = new HashSet<>(getSiteWidePermissions(username, groups));
+		if (parent != null) {
+			permissions.addAll(parent.getSiteWidePermissions(username, groups));
+		}
+		return mapSiteWidePermissionsToPackageAvailableActions(permissions);
 	}
 
 	@Override
 	public boolean isSiteAdmin(String username, Collection<Group> groups) {
-		return getRolesForUser(username, groups).contains(ADMIN_NORMALIZED_ROLE);
+		return getRolesForUser(username, groups).contains(ADMIN_NORMALIZED_ROLE)
+				|| (parent != null && parent.isSiteAdmin(username, groups));
 	}
 
 	private Collection<String> getSiteWidePermissions(String username, Collection<Group> groups) {
@@ -123,8 +149,14 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 						permissions.addAll(rolePermissionMappings.getAllPermissions());
 					}
 				});
-				permissions.add(PERMISSION_CONTENT_READ);
+				// Only add read if the user actually has a role for the site
+				if (!isGlobal) {
+					permissions.add(PERMISSION_CONTENT_READ);
+				}
 			}
+		}
+		if (parent != null) {
+			permissions.addAll(parent.getUserPermissions(username, groups, isSystemAdmin));
 		}
 		return permissions;
 	}
@@ -145,8 +177,14 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 						permissions.addAll(rolePermissionMappings.getPermissionsForPath(path));
 					}
 				});
-				permissions.add(PERMISSION_CONTENT_READ);
+				// Only add read if the user actually has a role for the site
+				if (!isGlobal) {
+					permissions.add(PERMISSION_CONTENT_READ);
+				}
 			}
+		}
+		if (parent != null) {
+			permissions.addAll(parent.getUserPermissions(username, groups, path, isSystemAdmin));
 		}
 		return permissions;
 	}

--- a/studio/src/test/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImplTest.java
+++ b/studio/src/test/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImplTest.java
@@ -57,7 +57,7 @@ public class SitePermissionMappingsImplTest {
 
 	@Test
 	public void getAvailableActionsUsesDirectUserRoleMappingWithoutGroups() {
-		SitePermissionMappingsImpl userMapped = new SitePermissionMappingsImpl();
+		SitePermissionMappingsImpl userMapped = new SitePermissionMappingsImpl(false);
 		userMapped.addGroupToRolesMapping(new NormalizedGroup("jane"),
 			List.of(new NormalizedRole("author")));
 		userMapped.addRolePermissionMapping("author", authorRoleMappings());
@@ -77,7 +77,7 @@ public class SitePermissionMappingsImplTest {
 
 	@Test
 	public void isSiteAdminReturnsTrueWhenUserHasAdminRole() {
-		SitePermissionMappingsImpl adminMappings = new SitePermissionMappingsImpl();
+		SitePermissionMappingsImpl adminMappings = new SitePermissionMappingsImpl(false);
 		adminMappings.addGroupToRolesMapping(new NormalizedGroup("site_admin"),
 			List.of(new NormalizedRole("admin")));
 		adminMappings.addRolePermissionMapping("admin", authorRoleMappings());
@@ -129,7 +129,7 @@ public class SitePermissionMappingsImplTest {
 		authorRules.addRuleContentItemPermissionsMapping("/site/components/.*",
 			List.of(PERMISSION_CONTENT_WRITE));
 
-		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl();
+		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl(false);
 		siteMappings.addGroupToRolesMapping(new NormalizedGroup("site_author"),
 			List.of(new NormalizedRole("author")));
 		siteMappings.addRolePermissionMapping("author", authorRules);
@@ -158,7 +158,7 @@ public class SitePermissionMappingsImplTest {
 
 	@Test
 	public void getUserPermissionsReturnsEmptySetWhenSiteHasNoRoles() {
-		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl();
+		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl(false);
 
 		Set<String> sitePermissions = siteMappings.getUserPermissions("jane", Collections.emptyList(), false);
 		Set<String> pathPermissions = siteMappings.getUserPermissions("jane", Collections.emptyList(),
@@ -179,7 +179,7 @@ public class SitePermissionMappingsImplTest {
 	}
 
 	private static SitePermissionMappingsImpl editorialSiteMappings() {
-		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl();
+		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl(false);
 		siteMappings.addGroupToRolesMapping(new NormalizedGroup("site_author"),
 			List.of(new NormalizedRole("author")));
 		siteMappings.addRolePermissionMapping("author", authorRoleMappings());

--- a/studio/src/test/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImplTest.java
+++ b/studio/src/test/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImplTest.java
@@ -178,13 +178,31 @@ public class SitePermissionMappingsImplTest {
 		assertEquals(Set.of(PERMISSION_GET_CHILDREN, PERMISSION_CONTENT_READ), pathPermissions);
 	}
 
+	@Test
+	public void noMembershipUserHasNoReadPermission() {
+		List<Group> groups = List.of(group("test1"));
+		Set<String> sitePermissions = mappings.getUserPermissions("testuser", groups, false);
+		Set<String> pathPermissions = mappings.getUserPermissions("testuser", groups, "/site/website/index.xml", false);
+
+		assertTrue(sitePermissions.isEmpty());
+		assertTrue(pathPermissions.isEmpty());
+	}
+
 	private static SitePermissionMappingsImpl editorialSiteMappings() {
-		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl(false);
+		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl(globalPermissionMappingsMappings());
 		siteMappings.addGroupToRolesMapping(new NormalizedGroup("site_author"),
 			List.of(new NormalizedRole("author")));
 		siteMappings.addRolePermissionMapping("author", authorRoleMappings());
 		siteMappings.addRolePermissionMapping("*", wildcardRoleMappings());
 		siteMappings.addGroupToRolesMapping(new NormalizedGroup("no_permissions"), List.of(new NormalizedRole("no_permissions")));
+		return siteMappings;
+	}
+
+	private static SitePermissionMappingsImpl globalPermissionMappingsMappings() {
+		SitePermissionMappingsImpl siteMappings = new SitePermissionMappingsImpl(true);
+		siteMappings.addGroupToRolesMapping(new NormalizedGroup("test1"),
+			List.of(new NormalizedRole("test1")));
+		siteMappings.addGroupToRolesMapping(new NormalizedGroup("test1"), List.of(new NormalizedRole("test1")));
 		return siteMappings;
 	}
 

--- a/studio/src/test/java/org/craftercms/studio/impl/v2/service/content/internal/ContentTypeServiceInternalImplTest.java
+++ b/studio/src/test/java/org/craftercms/studio/impl/v2/service/content/internal/ContentTypeServiceInternalImplTest.java
@@ -16,13 +16,17 @@
 
 package org.craftercms.studio.impl.v2.service.content.internal;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.craftercms.studio.api.v1.exception.ContentNotFoundException;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
+import org.craftercms.studio.api.v2.dal.security.NormalizedRole;
 import org.craftercms.studio.api.v2.service.config.ConfigurationService;
 import org.craftercms.studio.api.v2.service.content.ContentService;
 import org.craftercms.studio.model.contentType.ContentType;
+import org.craftercms.studio.model.contentType.CopyDependency;
+import org.craftercms.studio.model.contentType.DeleteDependency;
 import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
@@ -38,7 +42,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.StreamSupport;
 
+import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -148,12 +156,54 @@ public class ContentTypeServiceInternalImplTest {
 		when(contentService.getContent(SITE_ID, CONTENT_TYPE_DEFINITION_PATH)).thenReturn(inputStream);
 		ContentType contentType = service.loadContentType(SITE_ID, CONTENT_TYPE);
 
-		String expectedJson = "{\"previewable\":true,\"imageThumbnail\":\"page-test1.png\",\"noThumbnail\":false,\"quickCreate\":true," +
-				"\"quickCreatePath\":\"/site/website/tests/{year}/{month}\",\"type\":\"unknown\",\"pathExcludes\":[\"^/site/website/tests/excluded.*\"," +
-				"\"^/site/website/tests/excluded2.*\"],\"pathIncludes\":[\"^/site/website/tests/.*\"],\"id\":\"myContentType\"," +
-				"\"label\":\"Test Content Type\",\"allowedRoles\":[{\"name\":\"author\"},{\"name\":\"admin\"}]," +
-				"\"deleteDependencies\":[{\"pattern\":\"^/site/website/articles/.*\",\"removeEmptyFolder\":true}]," +
-				"\"copyDependencies\":[{\"pattern\":\"^/site/website/articles/.*\",\"target\":\"/site/website/articles2\"}]}";
-		assertEquals(expectedJson, new ObjectMapper().writeValueAsString(contentType));
+		JsonNode expected = new ObjectMapper().readTree("""
+				{
+					"previewable": true,
+					"imageThumbnail": "page-test1.png",
+					"noThumbnail": false,
+					"quickCreate": true,
+					"quickCreatePath": "/site/website/tests/{year}/{month}",
+					"type": "unknown",
+					"pathExcludes": ["^/site/website/tests/excluded.*", "^/site/website/tests/excluded2.*"],
+					"pathIncludes": ["^/site/website/tests/.*"],
+					"id": "myContentType",
+					"label": "Test Content Type",
+					"allowedRoles": [{"name": "author"}, {"name": "admin"}],
+					"deleteDependencies": [{"pattern": "^/site/website/articles/.*", "removeEmptyFolder": true}],
+					"copyDependencies": [{"pattern": "^/site/website/articles/.*", "target": "/site/website/articles2"}]
+				}
+				""");
+
+		assertEquals(expected.get("previewable").asBoolean(), contentType.isPreviewable());
+		assertEquals(expected.get("imageThumbnail").asText(), contentType.getImageThumbnail());
+		assertEquals(expected.get("noThumbnail").asBoolean(), contentType.isNoThumbnail());
+		assertEquals(expected.get("quickCreate").asBoolean(), contentType.isQuickCreate());
+		assertEquals(expected.get("quickCreatePath").asText(), contentType.getQuickCreatePath());
+		assertEquals(ContentType.Type.valueOf(expected.get("type").asText()), contentType.getType());
+		assertEquals(jsonTextValues(expected.get("pathExcludes")), List.copyOf(contentType.getPathExcludes()));
+		assertEquals(jsonTextValues(expected.get("pathIncludes")), List.copyOf(contentType.getPathIncludes()));
+		assertEquals(expected.get("id").asText(), contentType.getId());
+		assertEquals(expected.get("label").asText(), contentType.getLabel());
+		assertEquals(
+			StreamSupport.stream(expected.get("allowedRoles").spliterator(), false)
+				.map(role -> new NormalizedRole(role.get("name").asText()))
+				.collect(toSet()),
+			new HashSet<>(contentType.getAllowedRoles()));
+		assertEquals(
+			List.of(new DeleteDependency(
+				expected.get("deleteDependencies").get(0).get("pattern").asText(),
+				expected.get("deleteDependencies").get(0).get("removeEmptyFolder").asBoolean())),
+			contentType.getDeleteDependencies());
+		assertEquals(
+			List.of(new CopyDependency(
+				expected.get("copyDependencies").get(0).get("pattern").asText(),
+				expected.get("copyDependencies").get(0).get("target").asText())),
+			contentType.getCopyDependencies());
+	}
+
+	private static List<String> jsonTextValues(JsonNode arrayNode) {
+		return StreamSupport.stream(arrayNode.spliterator(), false)
+			.map(JsonNode::asText)
+			.toList();
 	}
 }


### PR DESCRIPTION
Separate global role-permission mappings from site mappings
https://github.com/craftersoftware/craftercms/issues/8798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission evaluation by consistently combining global and site-specific roles and permissions.
  * Ensured inherited permissions are included in action, publishing, administration, and content-access checks.
  * Improved handling of site-level and global permission mappings for more reliable access control.
  * Users without matching memberships no longer receive unintended content permissions.
  * Improved consistency when loading and applying permissions across sites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->