### PR TITLE
Relativize deployer target path

### DIFF
--- a/deployer/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
+++ b/deployer/src/main/java/org/craftercms/deployer/impl/TargetServiceImpl.java
@@ -435,8 +435,8 @@ public class TargetServiceImpl implements TargetService, ApplicationListener<App
 			if (loadMode.isCreate()) {
 				FileUtils.deleteQuietly(configFile);
 			}
-
-			throw new TargetServiceException(format("Failed to load target for configuration file '%s'", configFile), e);
+			String relativePath = targetConfigFolder.toPath().relativize(configFile.toPath()).toString();
+			throw new TargetServiceException(format("Failed to load target for configuration file '%s'", relativePath), e);
 		}
 	}
 

--- a/modules.gradle
+++ b/modules.gradle
@@ -94,7 +94,11 @@ gradle.taskGraph.whenReady { graph ->
 			if (name == ':test') {
 				return rootProject.path
 			}
-			return name.substring(0, name.length() - ':test'.length())
+			def projectPath = name.substring(0, name.length() - ':test'.length())
+			if (!projectPath.startsWith(':')) {
+				projectPath = ':'+ projectPath
+			}
+			projectPath
 		}.toSet()
 
 	graph.allTasks.findAll { it instanceof Test }.each { task ->


### PR DESCRIPTION
Relativize deployer target path
Fix gradle test running
https://github.com/craftersoftware/craftercms-e/issues/1104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when target loading fails by showing a concise, relative configuration path.
  * Improved test task matching to correctly handle both qualified and colon-prefixed task names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->