### PR TITLE
Publish permission updates

### DIFF
--- a/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/PublishDialog/PublishDialogContainer.tsx
@@ -109,7 +109,7 @@ export function PublishDialogContainer(props: PublishDialogContainerProps) {
 		itemsAndDependenciesMap
 	} = usePublishState({ mainItems, childrenItems });
 	const { updateSubmittingOrHasPendingChanges } = useEnhancedDialogContext();
-	const hasPublishPermission = permissionsBySite[siteId].includes('publish_approve');
+	const hasPublishPermission = permissionsBySite[siteId].includes('publish_review');
 	const publishingTarget = useMemo(() => {
 		let target: InternalDialogState['publishingTarget'] = '';
 		if (mainItems) {

--- a/studio-ui/ui/app/src/components/PublishOnDemandWidget/PublishOnDemandWidget.tsx
+++ b/studio-ui/ui/app/src/components/PublishOnDemandWidget/PublishOnDemandWidget.tsx
@@ -134,7 +134,7 @@ export function PublishOnDemandWidget(props: PublishOnDemandWidgetProps) {
 	const [selectedMode, setSelectedMode] = useState<PublishOnDemandMode>(() => pickMode(mode));
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const permissionsBySite = usePermissionsBySite();
-	const hasPublishPermission = permissionsBySite[siteId]?.includes('publish_approve');
+	const hasPublishPermission = permissionsBySite[siteId]?.includes('publish_review');
 	const [hasInitialPublish, setHasInitialPublish] = useState(false);
 	const initialPublishItem = useContentItem('/site/website/index.xml');
 	const [initialPublishingTarget, setInitialPublishingTarget] = useState(null);

--- a/studio-ui/ui/app/src/components/PublishingDashboard/PublishingDashboard.tsx
+++ b/studio-ui/ui/app/src/components/PublishingDashboard/PublishingDashboard.tsx
@@ -40,7 +40,7 @@ export function PublishingDashboard(props: PublishingDashboardProps) {
 	const site = useActiveSiteId();
 	const userPermissions = user?.permissionsBySite[site] ?? [];
 	// TODO: These permission checks should be on the PublishOnDemand widget itself. Dashboard should only check for `publish` permission to render the widget or not.
-	const hasPublishPermission = userPermissions?.includes('publish_approve');
+	const hasPublishPermission = userPermissions?.includes('publish_review');
 	const allowedPublishOnDemandModes: PublishOnDemandMode[] = [];
 	if (hasPublishPermission) allowedPublishOnDemandModes.push('everything', 'studio', 'git');
 	const {

--- a/studio-ui/ui/app/src/components/PublishingPackageResubmitDialog/PublishingPackageResubmitDialogContainer.tsx
+++ b/studio-ui/ui/app/src/components/PublishingPackageResubmitDialog/PublishingPackageResubmitDialogContainer.tsx
@@ -78,7 +78,7 @@ export function PublishingPackageResubmitDialogContainer(props: PublishingPackag
 	} = usePublishState({ mainItems });
 	const { updateSubmittingOrHasPendingChanges } = useEnhancedDialogContext();
 	const disabled = isSubmitting;
-	const hasPublishPermission = permissionsBySite[siteId].includes('publish_approve');
+	const hasPublishPermission = permissionsBySite[siteId].includes('publish_review');
 	const showRequestApproval = hasPublishPermission;
 	const isRequestPublish = !hasPublishPermission || state.requestApproval;
 	// Submit button should be disabled when

--- a/studio/src/main/api/studio-api.yaml
+++ b/studio/src/main/api/studio-api.yaml
@@ -6146,7 +6146,7 @@ paths:
             summary: Publishes the given content to the target (staging or live)
             description: |
                     Module: Studio <br>
-                    Required permission "publish_request". Additionally requires "publish_approve" when requestApproval is false. <br />
+                    Required permission "publish_request". Additionally requires "publish_review" when requestApproval is false. <br />
             operationId: publish
             parameters:
                 -   name: siteId
@@ -8004,7 +8004,7 @@ paths:
             summary: Approve request publish submission
             description: |
                     Module: Studio <br>
-                    Required permission "publish_approve"
+                    Required permission "publish_review"
             operationId: workflowApprove
             parameters:
                 -   name: site
@@ -8068,7 +8068,7 @@ paths:
             summary: Reject publish package
             description: |
                     Module: Studio <br>
-                    Required permission "publish_cancel"
+                    Required permission "publish_review"
             operationId: workflowReject
             parameters:
                 -   name: site

--- a/studio/src/main/api/studio-api.yaml
+++ b/studio/src/main/api/studio-api.yaml
@@ -6589,7 +6589,7 @@ paths:
             summary: Get available publishing targets for site
             description: |
                     Module: Studio <br>
-                    Required permission "publish_request"
+                    Required permission "content_read"
             operationId: getAvailablePublishingTargets
             parameters:
                 -   name: siteId

--- a/studio/src/main/api/studio-api.yaml
+++ b/studio/src/main/api/studio-api.yaml
@@ -6100,12 +6100,14 @@ paths:
                                             items:
                                                 type: array
                                                 items:
-                                                    $ref: '#/components/schemas/LightItem'
+                                                    $ref: '#/components/schemas/PublishDependency'
                                                 example:
                                                     - path: "/site/website/article1/index.xml"
                                                       label: "Article 1"
                                                       systemType: page
                                                       mimeType: application/xml
+                                                      canApprove: true
+                                                      canRequestPublish: true
                                             deletedItems:
                                                 type: array
                                                 items:
@@ -6115,21 +6117,25 @@ paths:
                                             hardDependencies:
                                                 type: array
                                                 items:
-                                                    $ref: '#/components/schemas/LightItem'
+                                                    $ref: '#/components/schemas/PublishDependency'
                                                 example:
                                                     - path: "/templates/web/article.ftl"
                                                       label: article.ftl
                                                       systemType: renderingTemplate
                                                       mimeType: text/x-freemarker
+                                                      canApprove: true
+                                                      canRequestPublish: false
                                             softDependencies:
                                                 type: array
                                                 items:
-                                                    $ref: '#/components/schemas/LightItem'
+                                                    $ref: '#/components/schemas/PublishDependency'
                                                 example:
                                                     - path: "/static-assets/images/background.png"
                                                       label: background.png
                                                       systemType: asset
                                                       mimeType: image/png
+                                                      canApprove: false
+                                                      canRequestPublish: true
                 '400':
                     $ref: '#/components/responses/BadRequest'
                 '401':
@@ -6506,12 +6512,14 @@ paths:
                                             items:
                                                 type: array
                                                 items:
-                                                    $ref: '#/components/schemas/LightItem'
+                                                    $ref: '#/components/schemas/PublishDependency'
                                                 example:
                                                     - path: "/site/website/article1/index.xml"
                                                       label: "Article 1"
                                                       systemType: page
                                                       mimeType: application/xml
+                                                      canApprove: true
+                                                      canRequestPublish: true
                                             deletedItems:
                                                 type: array
                                                 items:
@@ -6521,21 +6529,25 @@ paths:
                                             hardDependencies:
                                                 type: array
                                                 items:
-                                                    $ref: '#/components/schemas/LightItem'
+                                                    $ref: '#/components/schemas/PublishDependency'
                                                 example:
                                                     - path: "/templates/web/article.ftl"
                                                       label: article.ftl
                                                       systemType: renderingTemplate
                                                       mimeType: text/x-freemarker
+                                                      canApprove: true
+                                                      canRequestPublish: false
                                             softDependencies:
                                                 type: array
                                                 items:
-                                                    $ref: '#/components/schemas/LightItem'
+                                                    $ref: '#/components/schemas/PublishDependency'
                                                 example:
                                                     - path: "/static-assets/images/background.png"
                                                       label: background.png
                                                       systemType: asset
                                                       mimeType: image/png
+                                                      canApprove: false
+                                                      canRequestPublish: true
                 '400':
                     $ref: '#/components/responses/BadRequest'
                 '401':
@@ -9967,6 +9979,20 @@ components:
                 mimeType:
                     type: string
                     description: MIME-type of the content item file
+
+        PublishDependency:
+            type: object
+            description: publish dependency object
+            allOf:
+                -   $ref: '#/components/schemas/LightItem'
+                -   type: object
+                    properties:
+                        canApprove:
+                            type: boolean
+                            description: true if current user can approve the publish dependency, otherwise false
+                        canRequestPublish:
+                            type: boolean
+                            description: true if current user can request publish for the publish dependency, otherwise false
 
         PublishTaskProgress:
             type: object

--- a/studio/src/main/java/org/craftercms/studio/api/v2/dal/publish/PublishDAO.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/dal/publish/PublishDAO.java
@@ -417,7 +417,7 @@ public interface PublishDAO {
 	 * @param limit     the max number of items to return
 	 * @return failed PublishItem records for the package
 	 */
-	default Collection<PublishItem> getFailedPublishItems(String siteId, long packageId, int offset, int limit) {
+	default Collection<PublishItem> getFailedPublishItems(String siteId, long packageId, Integer offset, Integer limit) {
 		return getPublishItemsInternal(siteId, packageId, LIVE_FAILED.value | STAGING_FAILED.value, offset, limit);
 	}
 

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/ContentItemAvailableActionsConstants.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/ContentItemAvailableActionsConstants.java
@@ -201,7 +201,7 @@ public final class ContentItemAvailableActionsConstants {
 		long result = 0;
 		if (permissions.contains(PERMISSION_PUBLISH_REQUEST)) {
 			result |= PUBLISH_REQUEST;
-			if (permissions.contains(PERMISSION_PUBLISH_REQUEST) && permissions.contains(PERMISSION_PUBLISH_APPROVE)) {
+			if (permissions.contains(PERMISSION_PUBLISH_REVIEW)) {
 				result |= PUBLISH;
 			}
 		}

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/ContentItemAvailableActionsConstants.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/ContentItemAvailableActionsConstants.java
@@ -218,6 +218,8 @@ public final class ContentItemAvailableActionsConstants {
 			case PERMISSION_FOLDER_CREATE -> BITMAP_FOLDER_CREATE;
 			case PERMISSION_CONTENT_DELETE -> BITMAP_CONTENT_DELETE;
 			case PERMISSION_ITEM_UNLOCK -> BITMAP_ITEM_UNLOCK;
+			case PERMISSION_PUBLISH_REQUEST -> PUBLISH_REQUEST;
+			case PERMISSION_PUBLISH_REVIEW -> PUBLISH;
 			default -> {
 				logger.debug("Permission '{}' is not declared with content item available actions", permission);
 				yield BITMAP_UNDEFINED;

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/ContentItemAvailableActionsConstants.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/ContentItemAvailableActionsConstants.java
@@ -71,14 +71,12 @@ public final class ContentItemAvailableActionsConstants {
 		0b0000000000000000000000000000000000000000000010000000000000000000L;
 	public static final long PUBLISH =
 		0b0000000000000000000000000000000000000000000100000000000000000000L;
-	// Approve is now a package-level action
-	public static final long RETIRED_PUBLISH_APPROVED =
+	public static final long PUBLISH_APPROVE =
 		0b0000000000000000000000000000000000000000001000000000000000000000L;
 	// Items can be "scheduled" (submitted to publish) at any time (it will be just PUBLISH)
 	public static final long RETIRED_PUBLISH_SCHEDULE =
 		0b0000000000000000000000000000000000000000010000000000000000000000L;
-	// Reject is now a package-level action
-	public static final long RETIRED_PUBLISH_REJECT =
+	public static final long PUBLISH_REJECT =
 		0b0000000000000000000000000000000000000000100000000000000000000000L;
 	public static final long ITEM_UNLOCK =
 		0b0000000000000000000000000000000000000001000000000000000000000000L;
@@ -181,7 +179,7 @@ public final class ContentItemAvailableActionsConstants {
 	public static final long BITMAP_CONTENT_DELETE =
 		CONTENT_DELETE + CONTENT_DELETE_CONTROLLER + CONTENT_DELETE_TEMPLATE;
 	// publish
-	public static final long BITMAP_PUBLISH = PUBLISH;
+	public static final long BITMAP_PUBLISH = PUBLISH + PUBLISH_APPROVE + PUBLISH_REJECT;
 	// item_unlock
 	public static final long BITMAP_ITEM_UNLOCK =
 		ITEM_UNLOCK;
@@ -219,7 +217,7 @@ public final class ContentItemAvailableActionsConstants {
 			case PERMISSION_CONTENT_DELETE -> BITMAP_CONTENT_DELETE;
 			case PERMISSION_ITEM_UNLOCK -> BITMAP_ITEM_UNLOCK;
 			case PERMISSION_PUBLISH_REQUEST -> PUBLISH_REQUEST;
-			case PERMISSION_PUBLISH_REVIEW -> PUBLISH;
+			case PERMISSION_PUBLISH_REVIEW -> PUBLISH_APPROVE | PUBLISH_REJECT;
 			default -> {
 				logger.debug("Permission '{}' is not declared with content item available actions", permission);
 				yield BITMAP_UNDEFINED;

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/ContentItemPossibleActionsConstants.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/ContentItemPossibleActionsConstants.java
@@ -24,59 +24,48 @@ import static org.craftercms.studio.api.v2.security.ContentItemAvailableActionsC
 
 public final class ContentItemPossibleActionsConstants {
 
-	/*
-		TODO:
-		Temporarily disabled RENAME permission until proper rename API is provided for all renamable content
-		types and system types.
+	/**
+	 * Common possible actions shared by all content item types.
 	 */
-	public static final long PAGE = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
-		CONTENT_GET_DEPENDENCIES + PUBLISH_REQUEST + CONTENT_CREATE + CONTENT_PASTE + CONTENT_EDIT +
-		CONTENT_CUT + CONTENT_DUPLICATE + CONTENT_CHANGE_TYPE + CONTENT_REVERT +
-		CONTENT_EDIT_CONTROLLER + CONTENT_EDIT_TEMPLATE + FOLDER_CREATE + CONTENT_DELETE +
-		CONTENT_DELETE_CONTROLLER + CONTENT_DELETE_TEMPLATE + PUBLISH +
-		ITEM_UNLOCK;
-
-	public static final long ASSET = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
-		CONTENT_GET_DEPENDENCIES + PUBLISH_REQUEST + CONTENT_EDIT + CONTENT_RENAME + CONTENT_CUT +
-		CONTENT_DUPLICATE + CONTENT_REVERT + CONTENT_DELETE + PUBLISH +
-		ITEM_UNLOCK;
-
-	/*
-		TODO:
-		Temporarily disabled RENAME permission until proper rename API is provided for all renamable content
-		types and system types.
-	 */
-	public static final long COMPONENT = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
-		CONTENT_GET_DEPENDENCIES + PUBLISH_REQUEST + CONTENT_EDIT +
-		CONTENT_CUT + CONTENT_DUPLICATE + CONTENT_CHANGE_TYPE + CONTENT_REVERT +
-		CONTENT_EDIT_CONTROLLER + CONTENT_EDIT_TEMPLATE + CONTENT_DELETE +
-		CONTENT_DELETE_CONTROLLER + CONTENT_DELETE_TEMPLATE + PUBLISH +
-		ITEM_UNLOCK;
-
-	/*
-		TODO:
-		Temporarily disabled RENAME permission until proper rename API is provided for all renamable content
-		types and system types.
-	 */
-	public static final long DOCUMENT = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
+	public static final long COMMON = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
 		CONTENT_GET_DEPENDENCIES + PUBLISH_REQUEST + CONTENT_EDIT + CONTENT_CUT +
 		CONTENT_DUPLICATE + CONTENT_REVERT + CONTENT_DELETE + PUBLISH +
 		ITEM_UNLOCK;
 
-	public static final long RENDERING_TEMPLATE = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
-		CONTENT_GET_DEPENDENCIES + PUBLISH_REQUEST + CONTENT_EDIT + CONTENT_RENAME + CONTENT_CUT +
-		CONTENT_DUPLICATE + CONTENT_REVERT + CONTENT_DELETE + PUBLISH +
-		ITEM_UNLOCK;
+	/*
+		TODO:
+		Temporarily disabled RENAME permission until proper rename API is provided for all renamable content
+		types and system types.
+	 */
+	public static final long PAGE = COMMON + CONTENT_CREATE + CONTENT_PASTE + CONTENT_CHANGE_TYPE +
+		CONTENT_EDIT_CONTROLLER + CONTENT_EDIT_TEMPLATE + FOLDER_CREATE +
+		CONTENT_DELETE_CONTROLLER + CONTENT_DELETE_TEMPLATE;
+
+	public static final long ASSET = COMMON + CONTENT_RENAME;
 
 	/*
 		TODO:
 		Temporarily disabled RENAME permission until proper rename API is provided for all renamable content
 		types and system types.
 	 */
-	public static final long TAXONOMY = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
-		CONTENT_GET_DEPENDENCIES + PUBLISH_REQUEST + CONTENT_EDIT + CONTENT_CUT +
-		CONTENT_DUPLICATE + CONTENT_REVERT + CONTENT_DELETE + PUBLISH +
-		ITEM_UNLOCK;
+	public static final long COMPONENT = COMMON + CONTENT_CHANGE_TYPE + CONTENT_EDIT_CONTROLLER +
+		CONTENT_EDIT_TEMPLATE + CONTENT_DELETE_CONTROLLER + CONTENT_DELETE_TEMPLATE;
+
+	/*
+		TODO:
+		Temporarily disabled RENAME permission until proper rename API is provided for all renamable content
+		types and system types.
+	 */
+	public static final long DOCUMENT = COMMON;
+
+	public static final long RENDERING_TEMPLATE = COMMON + CONTENT_RENAME;
+
+	/*
+		TODO:
+		Temporarily disabled RENAME permission until proper rename API is provided for all renamable content
+		types and system types.
+	 */
+	public static final long TAXONOMY = COMMON;
 
 	public static final long CONTENT_TYPE = PUBLISH + PUBLISH_REQUEST;
 
@@ -97,20 +86,14 @@ public final class ContentItemPossibleActionsConstants {
 
 	public static final long CONFIG_FOLDER = 0L;
 
-	public static final long SCRIPT = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
-		CONTENT_GET_DEPENDENCIES + PUBLISH_REQUEST + CONTENT_EDIT + CONTENT_RENAME + CONTENT_CUT +
-		CONTENT_DUPLICATE + CONTENT_REVERT + CONTENT_DELETE + PUBLISH +
-		ITEM_UNLOCK;
+	public static final long SCRIPT = COMMON + CONTENT_RENAME;
 
 	/*
 		TODO:
 		Temporarily disabled RENAME permission until proper rename API is provided for all renamable content
 		types and system types.
 	 */
-	public static final long LEVEL_DESCRIPTOR = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +
-		CONTENT_GET_DEPENDENCIES + PUBLISH_REQUEST + CONTENT_EDIT + CONTENT_CUT +
-		CONTENT_DUPLICATE + CONTENT_REVERT + CONTENT_DELETE + PUBLISH +
-		ITEM_UNLOCK;
+	public static final long LEVEL_DESCRIPTOR = COMMON;
 
 	// Semantics Matrix for available actions
 	public static final long ITEM_STATE_NEW = CONTENT_READ + CONTENT_COPY + CONTENT_READ_VERSION_HISTORY +

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/HasAllPermissionsAnnotationHandler.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/HasAllPermissionsAnnotationHandler.java
@@ -69,9 +69,7 @@ public class HasAllPermissionsAnnotationHandler extends AbstractPermissionAnnota
 		}
 
 		try {
-			for (String action : actions) {
-				allowed = allowed && permissionEvaluator.isAllowed(securedResource, action);
-			}
+			allowed = PermissionCheckingUtils.hasAllPermissions(permissionEvaluator, securedResource, actions);
 		} catch (PermissionException e) {
 			throw new PermissionException(ERROR_KEY_EVALUATION_FAILED, e);
 		}

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/PermissionCheckingUtils.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/PermissionCheckingUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.studio.api.v2.security;
+
+import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getCurrentUsername;
+import static org.craftercms.studio.permissions.StudioPermissionsConstants.PATH_LIST_RESOURCE_ID;
+import static org.craftercms.studio.permissions.StudioPermissionsConstants.SITE_ID_RESOURCE_ID;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import org.craftercms.commons.security.exception.ActionDeniedException;
+import org.craftercms.commons.security.permissions.PermissionEvaluator;
+
+public class PermissionCheckingUtils {
+
+	/**
+	 * Checks if the current user has all the given permissions for the given
+	 * secured resource.
+	 *
+	 * @param permissionEvaluator the permission evaluator
+	 * @param securedResource     the secured resource
+	 * @param actions             the actions
+	 * @return true if the current user has all the given permissions for the given
+	 *         secured resource, false otherwise
+	 */
+	public static boolean hasAllPermissions(PermissionEvaluator permissionEvaluator, Object securedResource,
+			String... actions) {
+		return Arrays.stream(actions).allMatch(action -> permissionEvaluator.isAllowed(getCurrentUsername(),securedResource, action));
+	}
+
+	/**
+	 * Checks if the current user has all the given permissions for the given
+	 * secured resource. If the current user does not have all the given
+	 * permissions,
+	 * it throws an ActionDeniedException.
+	 *
+	 * @param permissionEvaluator the permission evaluator
+	 * @param securedResource     the secured resource
+	 * @param actions             the actions
+	 * @throws ActionDeniedException if the current user does not have all the given
+	 *                               permissions
+	 */
+	public static void checkPermissions(PermissionEvaluator permissionEvaluator, Object securedResource,
+			Collection<String> actions) {
+		for (String action : actions) {
+			if (!permissionEvaluator.isAllowed(getCurrentUsername(), securedResource, action)) {
+				throw new ActionDeniedException(action, securedResource);
+			}
+		}
+	}
+
+	/**
+	 * Returns the secured resource for the given site id.
+	 *
+	 * @param siteId the site id
+	 * @return the secured resource
+	 */
+	public static Object getSecuredResource(String siteId) {
+		return Map.of(SITE_ID_RESOURCE_ID, siteId);
+	}
+
+	/**
+	 * Returns the secured resource for the given site id and paths.
+	 *
+	 * @param siteId the site id
+	 * @param paths  the paths
+	 * @return the secured resource
+	 */
+	public static Object getSecuredResource(String siteId, Collection<String> paths) {
+		return Map.of(SITE_ID_RESOURCE_ID, siteId, PATH_LIST_RESOURCE_ID, paths);
+	}
+}

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/PermissionCheckingUtils.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/PermissionCheckingUtils.java
@@ -26,6 +26,9 @@ import java.util.Map;
 import org.craftercms.commons.security.exception.ActionDeniedException;
 import org.craftercms.commons.security.permissions.PermissionEvaluator;
 
+/**
+ * Utility class for checking permissions.
+ */
 public class PermissionCheckingUtils {
 
 	/**

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/SitePermissionMappings.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/SitePermissionMappings.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.craftercms.studio.api.v2.dal.Group;
+import org.craftercms.studio.api.v2.dal.publish.PublishItem;
+import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
 
 /**
  * Read-only mapping of user groups to available actions for a given site.
@@ -41,7 +43,7 @@ public interface SitePermissionMappings {
 	/**
 	 * Get the site wide available actions for a given user.
 	 * Site-wide actions are performed on the item-level, but are allowed on site-wide
-	 * permissions. e.g.: publish_request permission will allow PUBLISH_REQUEST
+	 * permissions. e.g.: publish_review permission will allow PUBLISH_REVIEW
 	 * action for any item in the site
 	 *
 	 * @param username username of the user
@@ -55,9 +57,11 @@ public interface SitePermissionMappings {
 	 *
 	 * @param username username of the user
 	 * @param groups groups the user belongs to
+	 * @param publishItems the publish items
+	 * @param isSystemAdmin true if the user is a system admin, false otherwise
 	 * @return available actions bitmap
 	 */
-	long getPublishPackageAvailableActions(String username, List<Group> groups);
+	long getPublishPackageAvailableActions(String username, List<Group> groups, Collection<PublishItem> publishItems, boolean isSystemAdmin);
 
 	/**
 	 * Check if the user is a site admin

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/SitePermissionMappings.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/SitePermissionMappings.java
@@ -22,7 +22,6 @@ import java.util.Set;
 
 import org.craftercms.studio.api.v2.dal.Group;
 import org.craftercms.studio.api.v2.dal.publish.PublishItem;
-import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
 
 /**
  * Read-only mapping of user groups to available actions for a given site.
@@ -48,9 +47,10 @@ public interface SitePermissionMappings {
 	 *
 	 * @param username username of the user
 	 * @param groups groups the user belongs to
+	 * @param isSystemAdmin true if the user is a system admin, false otherwise
 	 * @return available actions bitmap
 	 */
-	long getSiteWideItemAvailableActions(String username, List<Group> groups);
+	long getSiteWideItemAvailableActions(String username, List<Group> groups, boolean isSystemAdmin);
 
 	/**
 	 * Get the actions a user has permissions to perform on publish packages

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/publish/PeerReviewCapable.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/publish/PeerReviewCapable.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *     <li>OR the user is NOT the submitter of the package.</li>
  * </ul>
  * This annotation should be used in conjunction with {@link HasPermission} (or similar) to ensure the
- * user has {@code PERMISSION_PUBLISH_APPROVE} permission.
+ * user has {@code PERMISSION_PUBLISH_REVIEW} permission.
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/publish/PublishPackageAvailableActions.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/publish/PublishPackageAvailableActions.java
@@ -42,11 +42,8 @@ public final class PublishPackageAvailableActions {
 	 */
 	public static long mapSiteWidePermissionsToPackageAvailableActions(final Collection<String> permissions) {
 		long result = 0;
-		if (permissions.contains(PERMISSION_PUBLISH_APPROVE)) {
-			result |= APPROVE;
-		}
-		if (permissions.contains(PERMISSION_PUBLISH_REJECT)) {
-			result |= REJECT;
+		if (permissions.contains(PERMISSION_PUBLISH_REVIEW)) {
+			result |= APPROVE | REJECT;
 		}
 		if (permissions.contains(PERMISSION_PUBLISH_CANCEL)) {
 			result |= CANCEL;

--- a/studio/src/main/java/org/craftercms/studio/api/v2/security/publish/PublishPackageAvailableActions.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/security/publish/PublishPackageAvailableActions.java
@@ -35,12 +35,12 @@ public final class PublishPackageAvailableActions {
 	public static final long RESUBMIT = 1L << 3;
 
 	/**
-	 * Map site wide permissions to package available actions
+	 * Map  permissions to package available actions
 	 *
-	 * @param permissions site wide permissions
+	 * @param permissions permissions
 	 * @return bitmap of available actions
 	 */
-	public static long mapSiteWidePermissionsToPackageAvailableActions(final Collection<String> permissions) {
+	public static long mapPermissionsToPackageAvailableActions(final Collection<String> permissions) {
 		long result = 0;
 		if (permissions.contains(PERMISSION_PUBLISH_REVIEW)) {
 			result |= APPROVE | REJECT;

--- a/studio/src/main/java/org/craftercms/studio/api/v2/service/publish/PublishService.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/service/publish/PublishService.java
@@ -33,6 +33,9 @@ import org.craftercms.studio.impl.v2.publish.Publisher;
 import org.craftercms.studio.api.v2.dal.item.LightItem;
 import org.craftercms.studio.model.publish.PublishingTarget;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
@@ -310,8 +313,38 @@ public interface PublishService {
 	 * @param hardDependencies the hard dependencies of the items
 	 * @param softDependencies the soft dependencies of the items
 	 */
-	record CalculatedPublishPackageResult(Collection<LightItem> items, Collection<String> deletedItems,
-										  Collection<LightItem> hardDependencies,
-										  Collection<LightItem> softDependencies) {
+	record CalculatedPublishPackageResult(Collection<PublishDependency> items, Collection<String> deletedItems,
+										  Collection<PublishDependency> hardDependencies,
+										  Collection<PublishDependency> softDependencies) {
+	}
+
+	/**
+	 * LightItem wrapper with flags to indicate if the current user can approve or request publish for the item
+	 */
+	public static class PublishDependency {
+		@JsonUnwrapped
+		private final LightItem item;
+		@JsonProperty
+		private final boolean canApprove;
+		@JsonProperty
+		private final boolean canRequestPublish;
+
+		public PublishDependency(LightItem item, boolean canApprove, boolean canRequestPublish) {
+			this.item = item;
+			this.canApprove = canApprove;
+			this.canRequestPublish = canRequestPublish;
+		}
+
+		public LightItem getItem() {
+			return item;
+		}
+
+		public boolean canApprove() {
+			return canApprove;
+		}
+
+		public boolean canRequestPublish() {
+			return canRequestPublish;
+		}
 	}
 }

--- a/studio/src/main/java/org/craftercms/studio/api/v2/service/publish/PublishService.java
+++ b/studio/src/main/java/org/craftercms/studio/api/v2/service/publish/PublishService.java
@@ -263,10 +263,10 @@ public interface PublishService {
 	 * @param siteId    the site id
 	 * @param packageId the package id
 	 * @param offset    the offset to start from
-	 * @param limit     the max number of items to return
+	 * @param limit     the max number of items to return (null to return all items)
 	 * @return the publish items
 	 */
-	Collection<PublishItem> getPublishItems(String siteId, long packageId, int offset, int limit) throws PublishPackageNotFoundException, SiteNotFoundException;
+	Collection<PublishItem> getPublishItems(String siteId, long packageId, Integer offset, Integer limit) throws PublishPackageNotFoundException, SiteNotFoundException;
 
 	/**
 	 * Get the failed publish items for a package
@@ -275,10 +275,10 @@ public interface PublishService {
 	 * @param siteId    the site id
 	 * @param packageId the package id
 	 * @param offset    the offset to start from
-	 * @param limit     the max number of items to return
+	 * @param limit     the max number of items to return (null to return all items)
 	 * @return the failed publish items
 	 */
-	Collection<PublishItem> getFailedPublishItems(String siteId, long packageId, int offset, int limit);
+	Collection<PublishItem> getFailedPublishItems(String siteId, long packageId, Integer offset, Integer limit);
 
 	/**
 	 * Get the total number of published items in the last <code>days</code>number of days matching the action

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/AvailableActionsResolverImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/AvailableActionsResolverImpl.java
@@ -55,7 +55,7 @@ public class AvailableActionsResolverImpl implements AvailableActionsResolver {
 	public long getSiteWideActions(String siteId, String username) throws ServiceLayerException, UserNotFoundException {
 		List<Group> groups = userService.getUserGroups(-1, username);
 		SitePermissionMappings sitePermissionMappings = permissionMappingsProvider.getPermissionMappings(siteId);
-		return sitePermissionMappings.getSiteWideItemAvailableActions(username, groups);
+		return sitePermissionMappings.getSiteWideItemAvailableActions(username, groups, userService.isSystemAdmin(username));
 	}
 
 	private long calculateAvailableActions(String username, String path,

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/RolePermissionMappingsImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/RolePermissionMappingsImpl.java
@@ -34,7 +34,7 @@ import static org.craftercms.studio.permissions.StudioPermissionsConstants.SITE_
  * Instances will keep a map of rules to available actions for a given role.
  * It will also keep a set of site wide permissions. These are meant to be merged for all roles and then be used
  * to determine site-wide actions. e.g.: a user can be assigned a role with PUBLISH_REQUEST permission and another
- * one with PUBLISH_APPROVE permission. Such user would get the PUBLISH available action.
+ * one with PUBLISH_REVIEW permission. Such user would get the PUBLISH available action.
  */
 public class RolePermissionMappingsImpl implements RolePermissionMappings {
 

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/SemanticsAvailableActionsResolverImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/SemanticsAvailableActionsResolverImpl.java
@@ -23,6 +23,7 @@ import org.craftercms.studio.api.v1.exception.security.UserNotFoundException;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v2.dal.ItemDAO;
 import org.craftercms.studio.api.v2.dal.ItemState;
+import org.craftercms.studio.api.v2.dal.SiteDAO;
 import org.craftercms.studio.api.v2.dal.item.ContentItem;
 import org.craftercms.studio.api.v2.repository.blob.StudioBlobStore;
 import org.craftercms.studio.api.v2.repository.blob.StudioBlobStoreResolver;
@@ -60,6 +61,7 @@ public class SemanticsAvailableActionsResolverImpl implements SemanticsAvailable
 	private ServicesConfig servicesConfig;
 	private StudioBlobStoreResolver studioBlobStoreResolver;
 	private ContentTypeService contentTypeService;
+	private SiteDAO siteDAO;
 
 	@Override
 	public long calculateContentItemAvailableActions(String username, String siteId, ContentItem detailedItem)
@@ -142,6 +144,13 @@ public class SemanticsAvailableActionsResolverImpl implements SemanticsAvailable
 			result &= ~CONTENT_RENAME;
 			result &= ~CONTENT_DUPLICATE;
 			result &= ~CONTENT_COPY;
+		}
+
+		boolean isPublished = siteDAO.getSite(siteId).getPublishedRepoCreated();
+		if (!isPublished) {
+			// If initial publish is not done, the user cannot request a publish (PUBLISH_REQUEST will be added back later if there is a site-wide rule
+			// granting the permission)
+			result &= ~PUBLISH_REQUEST;
 		}
 
 		List<String> protectedFolderPatterns = servicesConfig.getProtectedFolderPatterns(siteId);
@@ -274,5 +283,10 @@ public class SemanticsAvailableActionsResolverImpl implements SemanticsAvailable
 	@SuppressWarnings("unused")
 	public void setItemDAO(final ItemDAO itemDAO) {
 		this.itemDAO = itemDAO;
+	}
+
+	@SuppressWarnings("unused")
+	public void setSiteDAO(final SiteDAO siteDAO) {
+		this.siteDAO = siteDAO;
 	}
 }

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImpl.java
@@ -27,13 +27,15 @@ import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.ADMIN_NORMALIZED_ROLE;
 import org.craftercms.studio.api.v2.dal.Group;
+import org.craftercms.studio.api.v2.dal.publish.PublishItem;
 import org.craftercms.studio.api.v2.dal.security.NormalizedGroup;
 import org.craftercms.studio.api.v2.dal.security.NormalizedRole;
 import static org.craftercms.studio.api.v2.dal.security.NormalizedRole.WILDCARD_ROLE;
 import static org.craftercms.studio.api.v2.security.ContentItemAvailableActionsConstants.mapSiteWidePermissionsToItemAvailableActions;
 import org.craftercms.studio.api.v2.security.RolePermissionMappings;
 import org.craftercms.studio.api.v2.security.SitePermissionMappings;
-import static org.craftercms.studio.api.v2.security.publish.PublishPackageAvailableActions.mapSiteWidePermissionsToPackageAvailableActions;
+import org.craftercms.studio.api.v2.security.publish.PublishPackageAvailableActions;
+
 import static org.craftercms.studio.permissions.StudioPermissionsConstants.PERMISSION_CONTENT_READ;
 
 /**
@@ -86,12 +88,13 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 	}
 
 	@Override
-	public long getPublishPackageAvailableActions(String username, List<Group> groups) {
-		Set<String> permissions = new HashSet<>(getSiteWidePermissions(username, groups));
-		if (parent != null) {
-			permissions.addAll(parent.getSiteWidePermissions(username, groups));
-		}
-		return mapSiteWidePermissionsToPackageAvailableActions(permissions);
+	public long getPublishPackageAvailableActions(String username, List<Group> groups, Collection<PublishItem> publishItems, boolean isSystemAdmin) {
+		long result = 0;
+		result = publishItems.stream()
+				.map(pi-> getUserPermissions(username, groups, pi.getPath(), isSystemAdmin))
+				.map(PublishPackageAvailableActions::mapPermissionsToPackageAvailableActions)
+				.reduce((a, b) -> a & b).orElse(0L);
+		return result;
 	}
 
 	@Override

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImpl.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
+
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.ADMIN_NORMALIZED_ROLE;
 import org.craftercms.studio.api.v2.dal.Group;
 import org.craftercms.studio.api.v2.dal.publish.PublishItem;
@@ -81,19 +83,23 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 	@Override
 	public long getSiteWideItemAvailableActions(String username, List<Group> groups) {
 		Set<String> permissions = new HashSet<>(getSiteWidePermissions(username, groups));
-		if (parent != null) {
-			permissions.addAll(parent.getSiteWidePermissions(username, groups));
-		}
 		return mapSiteWidePermissionsToItemAvailableActions(permissions);
 	}
 
 	@Override
-	public long getPublishPackageAvailableActions(String username, List<Group> groups, Collection<PublishItem> publishItems, boolean isSystemAdmin) {
+	public long getPublishPackageAvailableActions(String username, List<Group> groups,
+			Collection<PublishItem> publishItems, boolean isSystemAdmin) {
 		long result = 0;
-		result = publishItems.stream()
-				.map(pi-> getUserPermissions(username, groups, pi.getPath(), isSystemAdmin))
-				.map(PublishPackageAvailableActions::mapPermissionsToPackageAvailableActions)
-				.reduce((a, b) -> a & b).orElse(0L);
+		// List is empty for initial publish
+		if (isEmpty(publishItems)) {
+			Collection<String> siteWidePermissions = getSiteWidePermissions(username, groups);
+			result = PublishPackageAvailableActions.mapPermissionsToPackageAvailableActions(siteWidePermissions);
+		} else {
+			result = publishItems.stream()
+					.map(pi -> getUserPermissions(username, groups, pi.getPath(), isSystemAdmin))
+					.map(PublishPackageAvailableActions::mapPermissionsToPackageAvailableActions)
+					.reduce((a, b) -> a & b).orElse(0L);
+		}
 		return result;
 	}
 
@@ -111,6 +117,9 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 			if (rolePermissionMappings != null) {
 				permissions.addAll(rolePermissionMappings.getSiteWidePermissions());
 			}
+		}
+		if (parent != null) {
+			permissions.addAll(parent.getSiteWidePermissions(username, groups));
 		}
 		return permissions;
 	}

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/SitePermissionMappingsImpl.java
@@ -81,8 +81,8 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 	}
 
 	@Override
-	public long getSiteWideItemAvailableActions(String username, List<Group> groups) {
-		Set<String> permissions = new HashSet<>(getSiteWidePermissions(username, groups));
+	public long getSiteWideItemAvailableActions(String username, List<Group> groups, boolean isSystemAdmin) {
+		Set<String> permissions = new HashSet<>(getSiteWidePermissions(username, groups, isSystemAdmin));
 		return mapSiteWidePermissionsToItemAvailableActions(permissions);
 	}
 
@@ -92,7 +92,7 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 		long result = 0;
 		// List is empty for initial publish
 		if (isEmpty(publishItems)) {
-			Collection<String> siteWidePermissions = getSiteWidePermissions(username, groups);
+			Collection<String> siteWidePermissions = getSiteWidePermissions(username, groups, isSystemAdmin);
 			result = PublishPackageAvailableActions.mapPermissionsToPackageAvailableActions(siteWidePermissions);
 		} else {
 			result = publishItems.stream()
@@ -109,17 +109,23 @@ public class SitePermissionMappingsImpl implements SitePermissionMappings {
 				|| (parent != null && parent.isSiteAdmin(username, groups));
 	}
 
-	private Collection<String> getSiteWidePermissions(String username, Collection<Group> groups) {
+	private Collection<String> getSiteWidePermissions(String username, Collection<Group> groups, boolean isSystemAdmin) {
 		List<NormalizedRole> rolesList = getRolesForUser(username, groups);
 		Set<String> permissions = new HashSet<>();
-		for (NormalizedRole role : rolesList) {
-			RolePermissionMappings rolePermissionMappings = rolePermissions.get(role);
-			if (rolePermissionMappings != null) {
+		if (isSystemAdmin) {
+			rolePermissions.values().forEach(rolePermissionMappings -> {
 				permissions.addAll(rolePermissionMappings.getSiteWidePermissions());
+			});
+		} else {
+			for (NormalizedRole role : rolesList) {
+				RolePermissionMappings rolePermissionMappings = rolePermissions.get(role);
+				if (rolePermissionMappings != null) {
+					permissions.addAll(rolePermissionMappings.getSiteWidePermissions());
+				}
 			}
 		}
 		if (parent != null) {
-			permissions.addAll(parent.getSiteWidePermissions(username, groups));
+			permissions.addAll(parent.getSiteWidePermissions(username, groups, isSystemAdmin));
 		}
 		return permissions;
 	}

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/security/publish/PublishPackageAvailableActionResolverImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/security/publish/PublishPackageAvailableActionResolverImpl.java
@@ -17,6 +17,7 @@
 package org.craftercms.studio.impl.v2.security.publish;
 
 import java.beans.ConstructorProperties;
+import java.util.Collection;
 import java.util.List;
 
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
@@ -24,10 +25,14 @@ import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.exception.security.UserNotFoundException;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v2.dal.Group;
+import org.craftercms.studio.api.v2.dal.publish.PublishDAO;
+import org.craftercms.studio.api.v2.dal.publish.PublishItem;
 import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
 import org.craftercms.studio.api.v2.security.publish.PublishPackageAvailableActionResolver;
 import static org.craftercms.studio.api.v2.security.publish.PublishPackageAvailableActions.APPROVE;
 import static org.craftercms.studio.api.v2.security.publish.PublishPackageAvailableActions.getPossibleActionsForPackageStates;
+
+import org.craftercms.studio.api.v2.service.publish.PublishService;
 import org.craftercms.studio.api.v2.service.security.UserService;
 import org.craftercms.studio.api.v2.security.PermissionMappingsProvider;
 import org.craftercms.studio.api.v2.security.SitePermissionMappings;
@@ -45,14 +50,17 @@ public class PublishPackageAvailableActionResolverImpl implements PublishPackage
 	private final PermissionMappingsProvider permissionMappingProvider;
 	private final UserService userService;
 	private final ServicesConfig servicesConfig;
+	private final PublishDAO publishDao;
 
-	@ConstructorProperties({"permissionMappingProvider", "userService", "servicesConfig"})
+	@ConstructorProperties({"permissionMappingProvider", "userService", "servicesConfig", "publishDao"})
 	public PublishPackageAvailableActionResolverImpl(PermissionMappingsProvider permissionMappingProvider,
 													 UserService userService,
-													 ServicesConfig servicesConfig) {
+													 ServicesConfig servicesConfig,
+													 PublishDAO publishDao) {
 		this.permissionMappingProvider = permissionMappingProvider;
 		this.userService = userService;
 		this.servicesConfig = servicesConfig;
+		this.publishDao = publishDao;
 	}
 
 	@Override
@@ -63,10 +71,11 @@ public class PublishPackageAvailableActionResolverImpl implements PublishPackage
 			return 0;
 		}
 		String siteId = publishPackage.getSite().getSiteId();
+		Collection<PublishItem> publishItems = publishDao.getPublishItems(siteId, publishPackage.getId());
 		SitePermissionMappings permissionMappings = permissionMappingProvider.getPermissionMappings(siteId);
 		List<Group> groups = userService.getUserGroups(-1, user);
 		boolean isSubmitter = publishPackage.getSubmitter().getUsername().equals(getCurrentUsername());
-		long userAllowedActions = permissionMappings.getPublishPackageAvailableActions(user, groups);
+		long userAllowedActions = permissionMappings.getPublishPackageAvailableActions(user, groups, publishItems, userService.isSystemAdmin(user));
 		long packageStateActions = getPossibleActionsForPackageStates(publishPackage.getPackageState(),
 			publishPackage.getApprovalState());
 

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
@@ -170,6 +170,7 @@ import org.craftercms.studio.api.v2.exception.contentType.ContentTypeInvalidLoca
 import org.craftercms.studio.api.v2.exception.repository.RepositoryException;
 import org.craftercms.studio.api.v2.repository.ContentWriteItem;
 import org.craftercms.studio.api.v2.repository.GitContentRepository;
+import org.craftercms.studio.api.v2.security.PermissionCheckingUtils;
 import org.craftercms.studio.api.v2.security.SemanticsAvailableActionsResolver;
 import org.craftercms.studio.api.v2.service.audit.ActivityStreamService;
 import org.craftercms.studio.api.v2.service.audit.AuditService;
@@ -252,6 +253,7 @@ import org.springframework.util.MimeType;
 import org.springframework.util.function.ThrowingSupplier;
 
 import com.google.common.collect.Lists;
+import com.thoughtworks.xstream.core.SecurityUtils;
 
 /**
  * Internal implementation of {@link ContentService}
@@ -732,10 +734,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 			throw new ServiceLayerException(format("Item list after lifecycle processing is empty, nothing to write for site '%s' path '%s'", siteId, targetPath));
 		}
 
-		Map<String, Object> resource = Map.of(SITE_ID_RESOURCE_ID, siteId, PATH_LIST_RESOURCE_ID, affectedPaths);
-		if (!permissionEvaluator.isAllowed(getCurrentUsername(), resource, PERMISSION_CONTENT_WRITE)) {
-			throw new ActionDeniedException(PERMISSION_CONTENT_WRITE, affectedPaths);
-		}
+		PermissionCheckingUtils.checkPermissions(permissionEvaluator, PermissionCheckingUtils.getSecuredResource(siteId, affectedPaths), List.of(PERMISSION_CONTENT_WRITE));
 
 		// Check permissions for the oldPath for move operations
 		if (sourcePath != null) {

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/PublishServiceImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/PublishServiceImpl.java
@@ -27,6 +27,7 @@ import org.craftercms.studio.api.v2.annotation.precondition.RequireSiteExists;
 import org.craftercms.studio.api.v2.annotation.precondition.RequireSiteReady;
 import org.craftercms.studio.api.v2.annotation.publish.PackageId;
 import org.craftercms.studio.api.v2.annotation.publish.RequirePackageExists;
+import org.craftercms.studio.api.v2.annotation.resourceids.ContentPathList;
 import org.craftercms.studio.api.v2.annotation.resourceids.SiteId;
 import org.craftercms.studio.api.v2.dal.publish.PublishItem;
 import org.craftercms.studio.api.v2.dal.publish.PublishItemWithMetadata;
@@ -94,7 +95,9 @@ public class PublishServiceImpl implements PublishService {
 
 	@Override
 	@RequireSiteReady
-	@HasAllPermissions(type = CompositePermission.class, actions = {PERMISSION_PUBLISH_REQUEST, PERMISSION_PUBLISH_REVIEW})
+	// Notice that here we just validate the user is a member of the site. The actual permission checking will
+	// need to be done in the publish service once the package is entirely calculated.
+	@HasAllPermissions(type = CompositePermission.class, actions = PERMISSION_CONTENT_READ)
 	@PeerReviewCapable
 	public long publish(@SiteId String siteId, String publishingTarget, List<PublishRequestPath> paths,
 						List<String> commitIds, Instant schedule, String title, String comment, boolean submitAll)
@@ -104,7 +107,9 @@ public class PublishServiceImpl implements PublishService {
 
 	@Override
 	@RequireSiteReady
-	@HasPermission(type = CompositePermission.class, action = PERMISSION_PUBLISH_REQUEST)
+	// Notice that here we just validate the user is a member of the site. The actual permission checking will
+	// need to be done in the publish service once the package is entirely calculated.
+	@HasPermission(type = CompositePermission.class, action = PERMISSION_CONTENT_READ)
 	public long requestPublish(@SiteId String siteId, String publishingTarget, List<PublishRequestPath> paths,
 							   List<String> commitIds, Instant schedule, String title, String comment, boolean submitAll)
 		throws AuthenticationException, ServiceLayerException {
@@ -127,7 +132,7 @@ public class PublishServiceImpl implements PublishService {
 
 	@Override
 	@RequireSiteExists
-	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_REQUEST)
+	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public CalculatedPublishPackageResult calculatePublishPackage(@SiteId String siteId, String publishingTarget, Collection<PublishRequestPath> paths,
 																  Collection<String> commitIds)
 		throws ServiceLayerException, IOException {
@@ -177,7 +182,7 @@ public class PublishServiceImpl implements PublishService {
 	@RequirePackageExists
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_GET_QUEUE)
 	public Collection<PublishItem> getPublishItems(@SiteId String siteId, @PackageId final long packageId,
-												   final int offset, final int limit)
+												   final Integer offset, final Integer limit)
 		throws PublishPackageNotFoundException, SiteNotFoundException {
 		return publishServiceInternal.getPublishItems(siteId, packageId, offset, limit);
 	}
@@ -185,13 +190,13 @@ public class PublishServiceImpl implements PublishService {
 	@Override
 	@RequireSiteExists
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_GET_QUEUE)
-	public Collection<PublishItem> getFailedPublishItems(@SiteId final String siteId, @PackageId final long packageId, int offset, int limit) {
+	public Collection<PublishItem> getFailedPublishItems(@SiteId final String siteId, @PackageId final long packageId, Integer offset, Integer limit) {
 		return publishServiceInternal.getFailedPublishItems(siteId, packageId, offset, limit);
 	}
 
 	@Override
 	@RequireSiteExists
-	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_REQUEST)
+	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public List<PublishingTarget> getAvailablePublishingTargets(@SiteId String siteId) throws SiteNotFoundException {
 		return publishServiceInternal.getAvailablePublishingTargets(siteId);
 	}

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/PublishServiceImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/PublishServiceImpl.java
@@ -141,7 +141,7 @@ public class PublishServiceImpl implements PublishService {
 
 	@Override
 	@RequirePackageExists
-	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_REQUEST)
+	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public CalculatedPublishPackageResult recalculatePublishPackage(@SiteId String site, @PackageId long packageId, String target)
 		throws ServiceLayerException {
 		return publishServiceInternal.recalculatePublishPackage(site, packageId, target);

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/PublishServiceImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/PublishServiceImpl.java
@@ -94,7 +94,7 @@ public class PublishServiceImpl implements PublishService {
 
 	@Override
 	@RequireSiteReady
-	@HasAllPermissions(type = CompositePermission.class, actions = {PERMISSION_PUBLISH_REQUEST, PERMISSION_PUBLISH_APPROVE})
+	@HasAllPermissions(type = CompositePermission.class, actions = {PERMISSION_PUBLISH_REQUEST, PERMISSION_PUBLISH_REVIEW})
 	@PeerReviewCapable
 	public long publish(@SiteId String siteId, String publishingTarget, List<PublishRequestPath> paths,
 						List<String> commitIds, Instant schedule, String title, String comment, boolean submitAll)

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
@@ -42,6 +42,7 @@ import org.craftercms.studio.api.v2.exception.publish.InvalidTargetException;
 import org.craftercms.studio.api.v2.exception.repository.RepositoryException;
 import org.craftercms.studio.api.v2.repository.GitContentRepository;
 import org.craftercms.studio.api.v2.security.PermissionCheckingUtils;
+import org.craftercms.studio.api.v2.security.SemanticsAvailableActionsResolver;
 import org.craftercms.studio.api.v2.security.publish.PublishPackageAvailableActionResolver;
 import org.craftercms.studio.api.v2.service.audit.ActivityStreamService;
 import org.craftercms.studio.api.v2.service.audit.AuditService;
@@ -118,7 +119,8 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 
 	@ConstructorProperties({"contentRepository", "retryingDatabaseOperationFacade", "itemService", "servicesConfig",
 			"auditService", "dependencyService", "publishDao", "itemTargetDao", "siteService",
-			"generalLockService", "publishPackageAvailableActionResolver", "activityService", "permissionEvaluator"})
+			"generalLockService", "publishPackageAvailableActionResolver",
+			"activityService", "permissionEvaluator"})
 	public PublishServiceInternalImpl(GitContentRepository contentRepository, RetryingDatabaseOperationFacade retryingDatabaseOperationFacade,
 									  ItemService itemService, ServicesConfig servicesConfig, AuditService auditService,
 									  DependencyService dependencyService, PublishDAO publishDao,
@@ -255,7 +257,27 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 		// Get hard deps of them all
 		Collection<LightItem> hardDependencies = dependencyService.getHardDependencies(siteId, target, corePackagePaths);
 		Collection<LightItem> coreItems = isNotEmpty(corePackagePaths) ? publishDao.getMetadata(siteId, corePackagePaths) : emptyList();
-		return new CalculatedPublishPackageResult(coreItems, deletedPaths, hardDependencies, softDependencies);
+		return new CalculatedPublishPackageResult(getPublishDependencies(siteId, coreItems), deletedPaths,
+		 getPublishDependencies(siteId, hardDependencies), getPublishDependencies(siteId, softDependencies));
+	}
+
+	/**
+	 * Map LightItem List to PublishDependency List
+	 *
+	 * @param siteId the site id
+	 * @param items  the LightItem List
+	 * @return the PublishDependency List, contains canApprove and canRequestPublish
+	 *         for each item
+	 */
+	private Collection<PublishDependency> getPublishDependencies(String siteId, Collection<LightItem> items) {
+		return items.stream()
+				.map(item -> {
+					Object resource = PermissionCheckingUtils.getSecuredResource(siteId, List.of(item.getPath()));
+					boolean canApprove = permissionEvaluator.isAllowed(resource, PERMISSION_PUBLISH_REVIEW);
+					boolean canRequestPublish = permissionEvaluator.isAllowed(resource, PERMISSION_PUBLISH_REQUEST);
+					return new PublishDependency(item, canApprove, canRequestPublish);
+				})
+				.collect(toList());
 	}
 
 	@Override

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
@@ -761,7 +761,7 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 	protected long buildInitialPublishPackage(Site site, String publishingTarget, boolean requestApproval, String title,
 			String comment)
 			throws AuthenticationException, ServiceLayerException {
-		checkPublishAllPermissions(site.getSiteId(), requestApproval);
+		checkPublishPermissions(site.getSiteId(), requestApproval, emptyList());
 
 		return buildPublishPackage(site, publishingTarget, INITIAL_PUBLISH, emptyList(), emptyList(), requestApproval,
 				null, title, comment, emptyList());
@@ -769,20 +769,31 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 
 	/**
 	 * Check if the current user has the necessary permissions to submit a publish
-	 * all (or initial publish) operation.
+	 * operation.
+	 * It checks the user has the right permissions for each path. If paths is empty
+	 * (publish all or initial publish), it checks the user has the right
+	 * permissions for the site.
 	 *
 	 * @param siteId          the site id
 	 * @param requestApproval whether to request approval
+	 * @param paths           the paths to check permissions for, empty for publish
+	 *                        all or initial publish
 	 * @throws ActionDeniedException if the current user does not have the necessary
 	 *                               permissions
 	 */
-	protected void checkPublishAllPermissions(String siteId, boolean requestApproval) {
+	protected void checkPublishPermissions(String siteId, boolean requestApproval, Collection<String> paths) {
 		List<String> actions = requestApproval ? List.of(PERMISSION_PUBLISH_REQUEST)
 				: List.of(PERMISSION_PUBLISH_REQUEST, PERMISSION_PUBLISH_REVIEW);
 
-		PermissionCheckingUtils.checkPermissions(permissionEvaluator,
-				PermissionCheckingUtils.getSecuredResource(siteId),
-				actions);
+		if (isEmpty(paths)) {
+			PermissionCheckingUtils.checkPermissions(permissionEvaluator,
+					PermissionCheckingUtils.getSecuredResource(siteId),
+					actions);
+		} else {
+			PermissionCheckingUtils.checkPermissions(permissionEvaluator,
+					PermissionCheckingUtils.getSecuredResource(siteId, paths),
+					actions);
+		}
 	}
 
 	/**
@@ -821,7 +832,7 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 	 */
 	protected long buildPublishAllPackage(Site site, String publishingTarget, String title,
 			String comment) throws AuthenticationException, ServiceLayerException {
-		checkPublishAllPermissions(site.getSiteId(), false);
+		checkPublishPermissions(site.getSiteId(), false, emptyList());
 
 		return buildPublishPackage(site, publishingTarget, PUBLISH_ALL, emptyList(), emptyList(),
 			false, null, title, comment, getPublishAllItems(site));
@@ -879,12 +890,7 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 				.map(PublishItem::getPath)
 				.collect(toSet());
 
-		List<String> actions = requestApproval ? List.of(PERMISSION_PUBLISH_REQUEST)
-				: List.of(PERMISSION_PUBLISH_REQUEST, PERMISSION_PUBLISH_REVIEW);
-
-		PermissionCheckingUtils.checkPermissions(permissionEvaluator,
-				PermissionCheckingUtils.getSecuredResource(site.getSiteId(), publishPaths),
-				actions);
+		checkPublishPermissions(site.getSiteId(), requestApproval, publishPaths);
 
 		return buildPublishPackage(site, target, ITEM_LIST, paths, commitIds, requestApproval, schedule, title, comment,
 				publishItems);

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
@@ -19,6 +19,8 @@ package org.craftercms.studio.impl.v2.service.publish.internal;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.craftercms.commons.rest.parameters.SortField;
+import org.craftercms.commons.security.exception.ActionDeniedException;
+import org.craftercms.commons.security.permissions.PermissionEvaluator;
 import org.craftercms.commons.security.permissions.annotations.ProtectedResourceId;
 import org.craftercms.studio.api.v1.constant.DmConstants;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
@@ -39,6 +41,7 @@ import org.craftercms.studio.api.v2.exception.InvalidParametersException;
 import org.craftercms.studio.api.v2.exception.publish.InvalidTargetException;
 import org.craftercms.studio.api.v2.exception.repository.RepositoryException;
 import org.craftercms.studio.api.v2.repository.GitContentRepository;
+import org.craftercms.studio.api.v2.security.PermissionCheckingUtils;
 import org.craftercms.studio.api.v2.security.publish.PublishPackageAvailableActionResolver;
 import org.craftercms.studio.api.v2.service.audit.ActivityStreamService;
 import org.craftercms.studio.api.v2.service.audit.AuditService;
@@ -86,6 +89,8 @@ import static org.craftercms.studio.api.v2.utils.StudioUtils.getSandboxRepoLockK
 import static org.craftercms.studio.impl.v1.repository.git.GitContentRepositoryConstants.IGNORE_FILES;
 import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getAuthentication;
 import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getCurrentUsername;
+import static org.craftercms.studio.permissions.StudioPermissionsConstants.PERMISSION_PUBLISH_REQUEST;
+import static org.craftercms.studio.permissions.StudioPermissionsConstants.PERMISSION_PUBLISH_REVIEW;
 import static org.craftercms.studio.permissions.StudioPermissionsConstants.SITE_ID_RESOURCE_ID;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
@@ -109,17 +114,18 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 	private final GeneralLockService generalLockService;
 	private final PublishPackageAvailableActionResolver publishPackageAvailableActionResolver;
 	private final ActivityStreamService activityService;
+	private final PermissionEvaluator<String, Object> permissionEvaluator;
 
 	@ConstructorProperties({"contentRepository", "retryingDatabaseOperationFacade", "itemService", "servicesConfig",
 			"auditService", "dependencyService", "publishDao", "itemTargetDao", "siteService",
-			"generalLockService", "publishPackageAvailableActionResolver", "activityService"})
+			"generalLockService", "publishPackageAvailableActionResolver", "activityService", "permissionEvaluator"})
 	public PublishServiceInternalImpl(GitContentRepository contentRepository, RetryingDatabaseOperationFacade retryingDatabaseOperationFacade,
 									  ItemService itemService, ServicesConfig servicesConfig, AuditService auditService,
 									  DependencyService dependencyService, PublishDAO publishDao,
 									  ItemTargetDAO itemTargetDao,
 									  SitesService siteService, GeneralLockService generalLockService,
 									  PublishPackageAvailableActionResolver publishPackageAvailableActionResolver,
-									  ActivityStreamService activityService) {
+									  ActivityStreamService activityService, PermissionEvaluator<String, Object> permissionEvaluator) {
 		this.contentRepository = contentRepository;
 		this.retryingDatabaseOperationFacade = retryingDatabaseOperationFacade;
 		this.itemService = itemService;
@@ -132,6 +138,7 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 		this.generalLockService = generalLockService;
 		this.publishPackageAvailableActionResolver = publishPackageAvailableActionResolver;
 		this.activityService = activityService;
+		this.permissionEvaluator = permissionEvaluator;
 	}
 
 	@Override
@@ -581,7 +588,10 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 				if (schedule != null) {
 					throw new InvalidParametersException("Failed to submit publish package: Cannot schedule a publish all operation");
 				}
-				return buildPublishAllPackage(site, publishingTarget, requestApproval, title, comment);
+				if(requestApproval) {
+					throw new InvalidParametersException("Failed to submit publish package: Cannot submit a publish all operation for approval");
+				}
+				return buildPublishAllPackage(site, publishingTarget, title, comment);
 			}
 
 			return buildItemListPackage(site, publishingTarget,
@@ -659,27 +669,20 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 									   final boolean requestApproval,
 									   final Instant schedule,
 									   final String title,
-									   final String comment,
-									   final GetPublishItems getPublishItemsFunction)
-		throws ServiceLayerException, AuthenticationException {
-		try {
-			// Combine list of paths and list of commit changes
-			Collection<PublishItem> publishItems = getPublishItemsFunction.get(site, paths, commitIds, target);
-			PublishPackage publishPackage = submitPublishPackage(site, target, packageType, requestApproval,
+			final String comment,
+			final Collection<PublishItem> publishItems)
+			throws ServiceLayerException, AuthenticationException {
+		PublishPackage publishPackage = submitPublishPackage(site, target, packageType, requestApproval,
 				schedule, title, comment, publishItems);
 
-			auditPublishSubmission(publishPackage, requestApproval ? OPERATION_REQUEST_PUBLISH : OPERATION_PUBLISH);
+		auditPublishSubmission(publishPackage, requestApproval ? OPERATION_REQUEST_PUBLISH : OPERATION_PUBLISH);
 
-			applicationContext.publishEvent(new WorkflowEvent(getAuthentication(),
-					site.getSiteId(), publishPackage.getId(), requestApproval ? SUBMIT : DIRECT_PUBLISH));
-			if (!requestApproval) {
-				notifyPublisher(publishPackage, site);
-			}
-			return publishPackage.getId();
-		} catch (IOException e) {
-			logger.error("Failed to submit publish package", e);
-			throw new ServiceLayerException("Failed to submit publish package", e);
+		applicationContext.publishEvent(new WorkflowEvent(getAuthentication(),
+				site.getSiteId(), publishPackage.getId(), requestApproval ? SUBMIT : DIRECT_PUBLISH));
+		if (!requestApproval) {
+			notifyPublisher(publishPackage, site);
 		}
+		return publishPackage.getId();
 	}
 
 	private PublishPackage submitPublishPackage(Site site, String target, PackageType packageType, boolean requestApproval,
@@ -725,19 +728,6 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 	}
 
 	/**
-	 * Functional interface for a method that creates a collection of {@link PublishItem} objects
-	 * for a given request
-	 */
-	@FunctionalInterface
-	protected interface GetPublishItems {
-		Collection<PublishItem> get(final Site site,
-									final Collection<PublishRequestPath> paths,
-									final Collection<String> commitIds,
-									final String target)
-			throws ServiceLayerException, IOException;
-	}
-
-	/**
 	 * Build an initial publish package for a site.
 	 *
 	 * @param site             the site
@@ -746,9 +736,31 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 	 * @param comment          the comment
 	 * @return created package id
 	 */
-	protected long buildInitialPublishPackage(Site site, String publishingTarget, boolean requestApproval, String title, String comment)
-		throws AuthenticationException, ServiceLayerException {
-		return buildPublishPackage(site, publishingTarget, INITIAL_PUBLISH, emptyList(), emptyList(), requestApproval, null, title, comment, (s, p, c, t) -> emptyList());
+	protected long buildInitialPublishPackage(Site site, String publishingTarget, boolean requestApproval, String title,
+			String comment)
+			throws AuthenticationException, ServiceLayerException {
+		checkPublishAllPermissions(site.getSiteId(), requestApproval);
+
+		return buildPublishPackage(site, publishingTarget, INITIAL_PUBLISH, emptyList(), emptyList(), requestApproval,
+				null, title, comment, emptyList());
+	}
+
+	/**
+	 * Check if the current user has the necessary permissions to submit a publish
+	 * all (or initial publish) operation.
+	 *
+	 * @param siteId          the site id
+	 * @param requestApproval whether to request approval
+	 * @throws ActionDeniedException if the current user does not have the necessary
+	 *                               permissions
+	 */
+	protected void checkPublishAllPermissions(String siteId, boolean requestApproval) {
+		List<String> actions = requestApproval ? List.of(PERMISSION_PUBLISH_REQUEST)
+				: List.of(PERMISSION_PUBLISH_REQUEST, PERMISSION_PUBLISH_REVIEW);
+
+		PermissionCheckingUtils.checkPermissions(permissionEvaluator,
+				PermissionCheckingUtils.getSecuredResource(siteId),
+				actions);
 	}
 
 	/**
@@ -781,13 +793,16 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 	 *
 	 * @param site             the site
 	 * @param publishingTarget the publishing target
-	 * @param requestApproval  whether to request approval
+	 * @param title            the title
 	 * @param comment          the comment
 	 * @return created package id
 	 */
-	protected long buildPublishAllPackage(Site site, String publishingTarget, boolean requestApproval, String title, String comment) throws AuthenticationException, ServiceLayerException {
+	protected long buildPublishAllPackage(Site site, String publishingTarget, String title,
+			String comment) throws AuthenticationException, ServiceLayerException {
+		checkPublishAllPermissions(site.getSiteId(), false);
+
 		return buildPublishPackage(site, publishingTarget, PUBLISH_ALL, emptyList(), emptyList(),
-			requestApproval, null, title, comment, (siteId, __, ___, ____) -> getPublishAllItems(siteId));
+			false, null, title, comment, getPublishAllItems(site));
 	}
 
 	/**
@@ -826,10 +841,31 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 	 * @return created package id
 	 */
 	protected long buildItemListPackage(Site site, String target, Collection<PublishRequestPath> paths,
-										Collection<String> commitIds, boolean requestApproval, Instant schedule,
-										String title, String comment)
-		throws ServiceLayerException, AuthenticationException {
-		return buildPublishPackage(site, target, ITEM_LIST, paths, commitIds, requestApproval, schedule, title, comment, this::getItemListPackageItems);
+			Collection<String> commitIds, boolean requestApproval, Instant schedule,
+			String title, String comment)
+			throws ServiceLayerException, AuthenticationException {
+
+		Collection<PublishItem> publishItems;
+		try {
+			publishItems = getItemListPackageItems(site, paths, commitIds, target);
+		} catch (IOException e) {
+			logger.error("Failed to submit publish package", e);
+			throw new ServiceLayerException("Failed to submit publish package", e);
+		}
+
+		Collection<String> publishPaths = publishItems.stream()
+				.map(PublishItem::getPath)
+				.collect(toSet());
+
+		List<String> actions = requestApproval ? List.of(PERMISSION_PUBLISH_REQUEST)
+				: List.of(PERMISSION_PUBLISH_REQUEST, PERMISSION_PUBLISH_REVIEW);
+
+		PermissionCheckingUtils.checkPermissions(permissionEvaluator,
+				PermissionCheckingUtils.getSecuredResource(site.getSiteId(), publishPaths),
+				actions);
+
+		return buildPublishPackage(site, target, ITEM_LIST, paths, commitIds, requestApproval, schedule, title, comment,
+				publishItems);
 	}
 
 }

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
@@ -315,12 +315,12 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 
 	@Override
 	public Collection<PublishItem> getPublishItems(final String siteId, final long packageId,
-												   final int offset, final int limit) {
+												   final Integer offset, final Integer limit) {
 		return publishDao.getPublishItems(siteId, packageId, offset, limit);
 	}
 
 	@Override
-	public Collection<PublishItem> getFailedPublishItems(String siteId, long packageId, int offset, int limit) {
+	public Collection<PublishItem> getFailedPublishItems(String siteId, long packageId, Integer offset, Integer limit) {
 		return publishDao.getFailedPublishItems(siteId, packageId, offset, limit);
 	}
 

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/workflow/WorkflowServiceImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/workflow/WorkflowServiceImpl.java
@@ -94,7 +94,7 @@ public class WorkflowServiceImpl implements WorkflowService {
 
 	@Override
 	@RequireSiteExists
-	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_REVIEW)
+	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public void rejectPackages(@SiteId String siteId, Collection<Long> packageIds, String comment) throws ServiceLayerException, AuthenticationException {
 		workflowServiceInternal.rejectPackages(siteId, packageIds, comment);
 	}

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/workflow/WorkflowServiceImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/workflow/WorkflowServiceImpl.java
@@ -85,7 +85,7 @@ public class WorkflowServiceImpl implements WorkflowService {
 
 	@Override
 	@RequireSiteExists
-	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_APPROVE)
+	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_REVIEW)
 	@PeerReviewCapable
 	public void approvePackages(@SiteId String siteId, @PackageIds Collection<Long> packageIds, Instant schedule, boolean updateSchedule, String comment)
 		throws AuthenticationException, ServiceLayerException {
@@ -94,7 +94,7 @@ public class WorkflowServiceImpl implements WorkflowService {
 
 	@Override
 	@RequireSiteExists
-	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_REJECT)
+	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_REVIEW)
 	public void rejectPackages(@SiteId String siteId, Collection<Long> packageIds, String comment) throws ServiceLayerException, AuthenticationException {
 		workflowServiceInternal.rejectPackages(siteId, packageIds, comment);
 	}

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/workflow/WorkflowServiceImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/workflow/WorkflowServiceImpl.java
@@ -85,7 +85,9 @@ public class WorkflowServiceImpl implements WorkflowService {
 
 	@Override
 	@RequireSiteExists
-	@HasPermission(type = DefaultPermission.class, action = PERMISSION_PUBLISH_REVIEW)
+	// Notice that here we just validate the user is a member of the site. The actual permission checking will
+	// be done in the internal service by checking all the items in the packages.
+	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	@PeerReviewCapable
 	public void approvePackages(@SiteId String siteId, @PackageIds Collection<Long> packageIds, Instant schedule, boolean updateSchedule, String comment)
 		throws AuthenticationException, ServiceLayerException {
@@ -94,6 +96,8 @@ public class WorkflowServiceImpl implements WorkflowService {
 
 	@Override
 	@RequireSiteExists
+	// Notice that here we just validate the user is a member of the site. The actual permission checking will
+	// be done in the internal service by checking all the items in the packages.
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public void rejectPackages(@SiteId String siteId, Collection<Long> packageIds, String comment) throws ServiceLayerException, AuthenticationException {
 		workflowServiceInternal.rejectPackages(siteId, packageIds, comment);

--- a/studio/src/main/java/org/craftercms/studio/impl/v2/service/workflow/internal/WorkflowServiceInternalImpl.java
+++ b/studio/src/main/java/org/craftercms/studio/impl/v2/service/workflow/internal/WorkflowServiceInternalImpl.java
@@ -18,15 +18,20 @@ package org.craftercms.studio.impl.v2.service.workflow.internal;
 
 import java.time.Instant;
 import static java.time.Instant.now;
+import static java.util.stream.Collectors.toSet;
+
 import java.util.Collection;
 import java.util.List;
 
+import org.craftercms.commons.security.permissions.PermissionEvaluator;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.exception.security.AuthenticationException;
 import org.craftercms.studio.api.v1.service.GeneralLockService;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v2.dal.AuditLog;
+
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.craftercms.studio.api.v2.dal.AuditLog.createAuditLogEntry;
 import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_APPROVE_PUBLISH_PACKAGE;
 import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_CANCEL_PUBLISH_PACKAGE;
@@ -38,6 +43,7 @@ import org.craftercms.studio.api.v2.dal.Site;
 import org.craftercms.studio.api.v2.dal.User;
 import org.craftercms.studio.api.v2.dal.item.ContentItem;
 import org.craftercms.studio.api.v2.dal.publish.PublishDAO;
+import org.craftercms.studio.api.v2.dal.publish.PublishItem;
 import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
 import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.ApprovalState.APPROVED;
 import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.ApprovalState.REJECTED;
@@ -46,6 +52,7 @@ import org.craftercms.studio.api.v2.event.workflow.WorkflowEvent;
 import org.craftercms.studio.api.v2.exception.publish.InvalidPackageStateException;
 import org.craftercms.studio.api.v2.exception.publish.PackageAlreadyApprovedException;
 import org.craftercms.studio.api.v2.exception.publish.PublishPackageNotFoundException;
+import org.craftercms.studio.api.v2.security.PermissionCheckingUtils;
 import org.craftercms.studio.api.v2.service.audit.ActivityStreamService;
 import org.craftercms.studio.api.v2.service.audit.AuditService;
 import org.craftercms.studio.api.v2.service.item.ItemService;
@@ -56,6 +63,8 @@ import static org.craftercms.studio.api.v2.utils.StudioUtils.getSandboxRepoLockK
 import org.craftercms.studio.impl.v2.utils.DateUtils;
 import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getAuthentication;
 import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getCurrentUser;
+import static org.craftercms.studio.permissions.StudioPermissionsConstants.PERMISSION_PUBLISH_REVIEW;
+
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +84,8 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 	private ServicesConfig servicesConfig;
 	private ApplicationEventPublisher eventPublisher;
 	private RetryingDatabaseOperationFacade retryingDatabaseOperationFacade;
+
+	private PermissionEvaluator permissionEvaluator;
 
 	@Override
 	public int getItemStatesTotal(String siteId, String path, Long states) {
@@ -101,6 +112,7 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 	public void approvePackages(final String siteId, final Collection<Long> packageIds,
 				   final Instant schedule, final boolean updateSchedule, final String comment)
 		throws AuthenticationException, ServiceLayerException {
+		checkReviewPermissions(siteId, packageIds);
 		for (Long packageId : packageIds) {
 			doReviewPackage(siteId, packageId, p -> {
 				if (APPROVED == p.getApprovalState()) {
@@ -112,6 +124,29 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 				p.setApprovalState(APPROVED);
 				p.setReviewerComment(comment);
 			}, OPERATION_APPROVE_PUBLISH_PACKAGE, WorkflowEvent.WorkFlowEventType.APPROVE);
+		}
+	}
+
+	/**
+	 * Check if the current user has the permission to review the packages
+	 *
+	 * @param siteId     the siteId
+	 * @param packageIds the packageIds
+	 */
+	private void checkReviewPermissions(String siteId, Collection<Long> packageIds) {
+		for (long packageId : packageIds) {
+			Collection<PublishItem> publishItems = publishDao.getPublishItems(siteId, packageId);
+			Object resource;
+			if (isEmpty(publishItems)) {
+				resource = PermissionCheckingUtils.getSecuredResource(siteId);
+			} else {
+				resource = PermissionCheckingUtils.getSecuredResource(siteId, publishItems.stream()
+						.map(PublishItem::getPath)
+						.collect(toSet()));
+			}
+			PermissionCheckingUtils.checkPermissions(permissionEvaluator,
+					resource,
+					List.of(PERMISSION_PUBLISH_REVIEW));
 		}
 	}
 
@@ -134,7 +169,9 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 
 	@Override
 	public void rejectPackages(final String siteId, final Collection<Long> packageIds, final String comment)
-		throws ServiceLayerException, AuthenticationException {
+			throws ServiceLayerException, AuthenticationException {
+		checkReviewPermissions(siteId, packageIds);
+
 		for (Long packageId : packageIds) {
 			doReviewPackage(siteId, packageId, p -> {
 				p.setApprovalState(REJECTED);
@@ -252,6 +289,10 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 
 	public void setRetryingDatabaseOperationFacade(final RetryingDatabaseOperationFacade retryingDatabaseOperationFacade) {
 		this.retryingDatabaseOperationFacade = retryingDatabaseOperationFacade;
+	}
+
+	public void setPermissionEvaluator(final PermissionEvaluator permissionEvaluator) {
+		this.permissionEvaluator = permissionEvaluator;
 	}
 
 	private interface PackageReview {

--- a/studio/src/main/java/org/craftercms/studio/permissions/StudioPermissionsConstants.java
+++ b/studio/src/main/java/org/craftercms/studio/permissions/StudioPermissionsConstants.java
@@ -43,8 +43,7 @@ public final class StudioPermissionsConstants {
 	public static final String PERMISSION_PUBLISH_STATUS = "publish_status";
 
 	public static final String PERMISSION_PUBLISH_CANCEL = "publish_cancel";
-	public static final String PERMISSION_PUBLISH_APPROVE = "publish_approve";
-	public static final String PERMISSION_PUBLISH_REJECT = "publish_reject";
+	public static final String PERMISSION_PUBLISH_REVIEW = "publish_review";
 	public static final String PERMISSION_PUBLISH_REQUEST = "publish_request";
 	public static final String PERMISSION_PUBLISH_GET_QUEUE = "publish_get_queue";
 	public static final String PERMISSION_PULL_FROM_REMOTE = "pull_from_remote";

--- a/studio/src/main/java/org/craftercms/studio/permissions/StudioPermissionsConstants.java
+++ b/studio/src/main/java/org/craftercms/studio/permissions/StudioPermissionsConstants.java
@@ -40,12 +40,14 @@ public final class StudioPermissionsConstants {
 	public static final String PERMISSION_ENCRYPTION_TOOL = "encryption_tool";
 	public static final String PERMISSION_GET_CHILDREN = "get_children";
 	public static final String PERMISSION_LIST_REMOTES = "list_remotes";
-	public static final String PERMISSION_PUBLISH_STATUS = "publish_status";
 
+	public static final String PERMISSION_PUBLISH_STATUS = "publish_status";
 	public static final String PERMISSION_PUBLISH_CANCEL = "publish_cancel";
 	public static final String PERMISSION_PUBLISH_REVIEW = "publish_review";
 	public static final String PERMISSION_PUBLISH_REQUEST = "publish_request";
 	public static final String PERMISSION_PUBLISH_GET_QUEUE = "publish_get_queue";
+	public static final String PERMISSION_START_STOP_PUBLISHER = "start_stop_publisher";
+
 	public static final String PERMISSION_PULL_FROM_REMOTE = "pull_from_remote";
 	public static final String PERMISSION_PUSH_TO_REMOTE = "push_to_remote";
 	public static final String PERMISSION_CONTENT_READ = "content_read";
@@ -78,7 +80,6 @@ public final class StudioPermissionsConstants {
 	public static final String PERMISSION_VIEW_LOGS = "view_logs";
 	public static final String PERMISSION_VIEW_LOG_LEVELS = "view_log_levels";
 	public static final String PERMISSION_CONFIGURE_LOG_LEVELS = "configure_log_levels";
-	public static final String PERMISSION_START_STOP_PUBLISHER = "start_stop_publisher";
 	public static final String PERMISSION_UNLOCK_REPO = "unlock_repository";
 	public static final String PERMISSION_REPAIR_REPOSITORY = "repair_repository";
 

--- a/studio/src/main/resources/crafter/studio/security/common.xml
+++ b/studio/src/main/resources/crafter/studio/security/common.xml
@@ -284,6 +284,7 @@
 		<property name="contentTypeService" ref="contentTypeServiceInternal"/>
 		<property name="userService" ref="userServiceInternal"/>
 		<property name="itemDAO" ref="itemDao"/>
+		<property name="siteDAO" ref="siteDao"/>
 	</bean>
 
 	<bean id="studio.loginPageFilter"

--- a/studio/src/main/resources/crafter/studio/studio-services-context.xml
+++ b/studio/src/main/resources/crafter/studio/studio-services-context.xml
@@ -399,6 +399,7 @@
 		<constructor-arg name="siteService" ref="sitesServiceInternal"/>
 		<constructor-arg name="auditService" ref="auditServiceInternal"/>
 		<constructor-arg name="dependencyService" ref="dependencyServiceInternal"/>
+		<constructor-arg name="permissionEvaluator" ref="crafter.studioCompositePermissionEvaluator"/>
 	</bean>
 
 	<bean id="dashboardService" class="org.craftercms.studio.impl.v2.service.dashboard.DashboardServiceImpl">
@@ -436,6 +437,7 @@
 		<property name="publishDao" ref="publishDao"/>
 		<property name="servicesConfig" ref="cstudioServicesConfig"/>
 		<property name="retryingDatabaseOperationFacade" ref="studio.retryingDatabaseOperationFacade"/>
+		<property name="permissionEvaluator" ref="crafter.studioCompositePermissionEvaluator"/>
 	</bean>
 
 	<bean id="studio.activityStreamService"

--- a/studio/src/main/resources/crafter/studio/upgrade/5.0.x/permission-mappings/permission-mappings-config-v5.0.0.0.xslt
+++ b/studio/src/main/resources/crafter/studio/upgrade/5.0.x/permission-mappings/permission-mappings-config-v5.0.0.0.xslt
@@ -89,7 +89,7 @@
                             <xsl:text>publish_request</xsl:text>
                         </xsl:element>
                         <xsl:element name="permission">
-                            <xsl:text>publish_approve</xsl:text>
+                            <xsl:text>publish_review</xsl:text>
                         </xsl:element>
                     </xsl:if>
                 </xsl:otherwise>
@@ -118,28 +118,18 @@
                 <xsl:text>publish_request</xsl:text>
             </xsl:element>
         </xsl:if>
-        <xsl:if test="not(permission = 'publish_approve')">
+        <xsl:if test="not(permission = 'publish_review')">
             <xsl:element name="permission">
-                <xsl:text>publish_approve</xsl:text>
-            </xsl:element>
-        </xsl:if>
-        <xsl:if test="not(permission = 'publish_reject')">
-            <xsl:element name="permission">
-                <xsl:text>publish_reject</xsl:text>
+                <xsl:text>publish_review</xsl:text>
             </xsl:element>
         </xsl:if>
     </xsl:template>
 
     <!-- Add permissions to reviewer role -->
     <xsl:template match="allowed-permissions" mode="reviewer">
-        <xsl:if test="not(permission = 'publish_approve')">
+        <xsl:if test="not(permission = 'publish_review')">
             <xsl:element name="permission">
-                <xsl:text>publish_approve</xsl:text>
-            </xsl:element>
-        </xsl:if>
-        <xsl:if test="not(permission = 'publish_reject')">
-            <xsl:element name="permission">
-                <xsl:text>publish_reject</xsl:text>
+                <xsl:text>publish_review</xsl:text>
             </xsl:element>
         </xsl:if>
     </xsl:template>
@@ -151,14 +141,9 @@
                 <xsl:text>publish_request</xsl:text>
             </xsl:element>
         </xsl:if>
-        <xsl:if test="not(permission = 'publish_approve')">
+        <xsl:if test="not(permission = 'publish_review')">
             <xsl:element name="permission">
-                <xsl:text>publish_approve</xsl:text>
-            </xsl:element>
-        </xsl:if>
-        <xsl:if test="not(permission = 'publish_reject')">
-            <xsl:element name="permission">
-                <xsl:text>publish_reject</xsl:text>
+                <xsl:text>publish_review</xsl:text>
             </xsl:element>
         </xsl:if>
     </xsl:template>

--- a/studio/src/main/resources/crafter/studio/upgrade/5.0.x/system/global-permission-mappings-config-v5.0.0.1.xslt
+++ b/studio/src/main/resources/crafter/studio/upgrade/5.0.x/system/global-permission-mappings-config-v5.0.0.1.xslt
@@ -51,15 +51,12 @@
 				<xsl:element name="permission">
 					<xsl:text>publish_request</xsl:text>
 				</xsl:element>
-				<xsl:element name="permission">
-					<xsl:text>publish_approve</xsl:text>
-				</xsl:element>
 			</xsl:if>
 
-			<xsl:if test="ancestor::role/@name = 'system_admin'">
-				<xsl:if test="not(permission = 'publish_reject')">
+			<xsl:if test="ancestor::role[1]/rule/allowed-permissions/permission[text() = 'publish'] or ancestor::role/@name = 'system_admin'">
+				<xsl:if test="not(permission = 'publish_review')">
 					<xsl:element name="permission">
-						<xsl:text>publish_reject</xsl:text>
+						<xsl:text>publish_review</xsl:text>
 					</xsl:element>
 				</xsl:if>
 			</xsl:if>

--- a/studio/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/permission-mappings-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/permission-mappings-config.xml
@@ -72,8 +72,7 @@
 				<permission>publish_get_queue</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -154,8 +153,7 @@
 				<permission>set_item_states</permission>
 				<permission>publish_get_queue</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -164,8 +162,7 @@
 			<allowed-permissions>
 				<permission>read_configuration</permission>
 				<permission>publish_get_queue</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>

--- a/studio/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/permission-mappings-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/permission-mappings-config.xml
@@ -72,8 +72,7 @@
 				<permission>publish_get_queue</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -154,8 +153,7 @@
 				<permission>set_item_states</permission>
 				<permission>publish_get_queue</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -164,8 +162,7 @@
 			<allowed-permissions>
 				<permission>read_configuration</permission>
 				<permission>publish_get_queue</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>

--- a/studio/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/permission-mappings-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/permission-mappings-config.xml
@@ -72,8 +72,7 @@
 				<permission>publish_get_queue</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -154,8 +153,7 @@
 				<permission>set_item_states</permission>
 				<permission>publish_get_queue</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -164,8 +162,7 @@
 			<allowed-permissions>
 				<permission>read_configuration</permission>
 				<permission>publish_get_queue</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>

--- a/studio/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/permission-mappings-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/permission-mappings-config.xml
@@ -72,8 +72,7 @@
 				<permission>publish_get_queue</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -154,8 +153,7 @@
 				<permission>set_item_states</permission>
 				<permission>publish_get_queue</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -164,8 +162,7 @@
 			<allowed-permissions>
 				<permission>read_configuration</permission>
 				<permission>publish_get_queue</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>

--- a/studio/src/main/webapp/repo-bootstrap/global/configuration/global-permission-mappings-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/configuration/global-permission-mappings-config.xml
@@ -98,8 +98,7 @@
 				<permission>cancel_failed_pull</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 				<permission>system_properties_read</permission>
 				<permission>system_properties_manage</permission>
 			</allowed-permissions>

--- a/studio/src/main/webapp/repo-bootstrap/global/configuration/samples/sample-permission-mappings-config.xml
+++ b/studio/src/main/webapp/repo-bootstrap/global/configuration/samples/sample-permission-mappings-config.xml
@@ -86,8 +86,7 @@
 				<permission>publish_get_queue</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -184,8 +183,7 @@
 				<permission>set_item_states</permission>
 				<permission>publish_get_queue</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -201,8 +199,7 @@
 				<permission>content_search</permission>
 				<permission>read_configuration</permission>
 				<permission>publish_get_queue</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>

--- a/studio/src/test/resources/crafter/studio/upgrade/xslt/global-permission-mappings/5.0/5.0.0.1/expected.xml
+++ b/studio/src/test/resources/crafter/studio/upgrade/xslt/global-permission-mappings/5.0/5.0.0.1/expected.xml
@@ -101,8 +101,7 @@
 				<permission>cancel_failed_pull</permission>
 				<permission>publish_cancel</permission>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
-				<permission>publish_reject</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>
@@ -126,7 +125,7 @@
 		<rule regex="/.*">
 			<allowed-permissions>
 				<permission>publish_request</permission>
-				<permission>publish_approve</permission>
+				<permission>publish_review</permission>
 			</allowed-permissions>
 		</rule>
 	</role>

--- a/studio/src/test/resources/crafter/studio/upgrade/xslt/permission-mappings-config/5.0/5.0.0/expected.xml
+++ b/studio/src/test/resources/crafter/studio/upgrade/xslt/permission-mappings-config/5.0/5.0.0/expected.xml
@@ -85,8 +85,7 @@
                 <permission>publish_get_queue</permission>
                 <permission>publish_cancel</permission>
                 <permission>publish_request</permission>
-                <permission>publish_approve</permission>
-                <permission>publish_reject</permission>
+                <permission>publish_review</permission>
             </allowed-permissions>
         </rule>
     </role>
@@ -183,8 +182,7 @@
                 <permission>set_item_states</permission>
                 <permission>publish_get_queue</permission>
                 <permission>publish_request</permission>
-                <permission>publish_approve</permission>
-                <permission>publish_reject</permission>
+                <permission>publish_review</permission>
             </allowed-permissions>
         </rule>
     </role>
@@ -200,8 +198,7 @@
                 <permission>content_search</permission>
                 <permission>read_configuration</permission>
                 <permission>publish_get_queue</permission>
-                <permission>publish_approve</permission>
-                <permission>publish_reject</permission>
+                <permission>publish_review</permission>
             </allowed-permissions>
         </rule>
     </role>
@@ -232,7 +229,7 @@
                 <permission>publish_get_queue</permission>
                 <permission>publish_cancel</permission>
                 <permission>publish_request</permission>
-                <permission>publish_approve</permission>
+                <permission>publish_review</permission>
             </allowed-permissions>
         </rule>
     </role>


### PR DESCRIPTION
Decorate dependencies in publish package to indicate if user is allowed to publish/request
Enforce item-level permissions for publishing
Update available actions for publish packages
Combine publish_approve and publish_reject into publish_review permission
https://github.com/craftersoftware/craftercms/issues/8793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing workflows now use a unified review permission for requesting, approving, and rejecting publication.
  * Publishing actions reflect permissions for individual content items, including approval and publish-request availability.
  * Users with content access can view publishing targets and calculate publish packages.
  * Publish and failed-item lists can return all results without pagination limits.

* **Bug Fixes**
  * Publishing actions are hidden when a site is not ready for publishing.
  * Updated role permissions to support the unified publishing review workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->