### PR TITLE
[8881] Switching between sites can break Studio and cause React exception

### DIFF
--- a/studio-ui/ui/app/src/components/Preview/Preview.tsx
+++ b/studio-ui/ui/app/src/components/Preview/Preview.tsx
@@ -188,7 +188,7 @@ function Preview() {
 			>
 				{/* If there is no site set (no crafterSite cookie), there'll be a changeSite event that will set the site based on the query string parameter. In the
 				 meantime, we'll show a loading state. */}
-				{priorState.current.site ? (
+				{site ? (
 					<>
 						<ToolBar />
 						<Host />

--- a/studio-ui/ui/app/src/components/Preview/Preview.tsx
+++ b/studio-ui/ui/app/src/components/Preview/Preview.tsx
@@ -33,6 +33,7 @@ import { GlobalRoutes } from '../../env/routes';
 import LookupTable from '../../models/LookupTable';
 import { changeSite } from '../../state/actions/sites';
 import { changeCurrentUrl } from '../../state/actions/preview';
+import LoadingState from '../LoadingState';
 
 const notValidSiteRedirect = (message: string, url: string) => {
 	alert(message);
@@ -185,10 +186,18 @@ function Preview() {
 					background: theme.palette.background.default
 				})}
 			>
-				<ToolBar />
-				<Host />
-				<ToolsPanel />
-				<ICEToolsPanel />
+				{/* If there is no site set (no crafterSite cookie), there'll be a changeSite event that will set the site based on the query string parameter. In the
+				 meantime, we'll show a loading state. */}
+				{priorState.current.site ? (
+					<>
+						<ToolBar />
+						<Host />
+						<ToolsPanel />
+						<ICEToolsPanel />
+					</>
+				) : (
+					<LoadingState />
+				)}
 			</Box>
 		</PreviewConcierge>
 	);


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the preview experience while site data is loading.
  * Displays a loading state instead of showing incomplete preview controls before the initial site is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->