### PR TITLE
SiteItemService return SiteItem only when matching allowed regexes

### DIFF
--- a/engine/src/main/java/org/craftercms/engine/service/SiteItemService.java
+++ b/engine/src/main/java/org/craftercms/engine/service/SiteItemService.java
@@ -130,4 +130,12 @@ public interface SiteItemService {
 	SiteItem getSiteTree(String url, int depth, String includeByNameRegex, String excludeByNameRegex,
 			     Map<String, String> nodeXPathAndExpectedValuePairs);
 
+	/**
+	 * Checks if the item exists at the given path.
+	 *
+	 * @param path the path to check
+	 * @return true if the item exists, false otherwise
+	 */
+	boolean exists(String path);
+
 }

--- a/engine/src/main/java/org/craftercms/engine/service/impl/SiteItemServiceImpl.java
+++ b/engine/src/main/java/org/craftercms/engine/service/impl/SiteItemServiceImpl.java
@@ -233,6 +233,11 @@ public class SiteItemServiceImpl implements SiteItemService {
 		}
 	}
 
+	@Override
+	public boolean exists(String path) {
+		return storeService.exists(getSiteContext().getContext(), path);
+	}
+
 	protected SiteContext getSiteContext() {
 		SiteContext siteContext = SiteContext.getCurrent();
 		if (siteContext == null) {

--- a/engine/src/main/java/org/craftercms/engine/util/config/profiles/ConfigurationProviderImpl.java
+++ b/engine/src/main/java/org/craftercms/engine/util/config/profiles/ConfigurationProviderImpl.java
@@ -41,7 +41,7 @@ public class ConfigurationProviderImpl implements ConfigurationProvider {
 
 	@Override
 	public boolean configExists(String path) {
-		return siteItemService.getSiteItem(path) != null;
+		return siteItemService.exists(path);
 	}
 
 	@Override

--- a/engine/src/main/java/org/craftercms/engine/util/predicates/IncludeByUrlPredicate.java
+++ b/engine/src/main/java/org/craftercms/engine/util/predicates/IncludeByUrlPredicate.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.engine.util.predicates;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.craftercms.core.service.Item;
+
+/**
+ * Predicate used to check if an item is included by its url.
+ *
+ **/
+public class IncludeByUrlPredicate implements Predicate<Item> {
+
+	private static final Log logger = LogFactory.getLog(IncludeByUrlPredicate.class);
+
+	protected List<Pattern> includePatterns;
+
+	public IncludeByUrlPredicate(String[] includeRegexes) {
+		this.includePatterns = Arrays.stream(includeRegexes).map(Pattern::compile).collect(Collectors.toList());
+	}
+
+	@Override
+	public boolean evaluate(Item item) {
+		return includePatterns.stream().anyMatch(p -> p.matcher(item.getUrl()).matches());
+	}
+
+}

--- a/engine/src/main/resources/crafter/engine/mode/preview/services-context.xml
+++ b/engine/src/main/resources/crafter/engine/mode/preview/services-context.xml
@@ -101,7 +101,10 @@
 	<!--									-->
 	<!-- ////////////////////////////////// -->
 
-	<util:list id="crafter.defaultItemPredicates"/>
+	<util:list id="crafter.defaultItemPredicates">
+		<!-- Allow items matching the include regexes only -->
+		<ref bean="crafter.includeByUrlItemPredicate"/>
+	</util:list>
 
 	<bean id="crafter.cacheTemplate" class="org.craftercms.core.util.cache.impl.NoopCacheTemplate">
 		<constructor-arg name="cacheService" ref="crafter.cacheService"/>

--- a/engine/src/main/resources/crafter/engine/server-config.properties
+++ b/engine/src/main/resources/crafter/engine/server-config.properties
@@ -29,6 +29,8 @@ crafter.engine.site.default.cache.maxAllowedItems=250000
 # (preview or multi-tenant modes). The value should be a String Resource URL, so it can start with classpath, file,
 # http, ftp, etc. When no prefix is present it means the folder is inside the webapp folder.
 crafter.engine.site.default.rootFolder.path=default-site
+# List of regular expressions for the paths that are allowed to be used as descriptor paths (the SiteItemService will only return items from these paths)
+crafter.engine.site.default.descriptors.allowed.paths=/site/.*
 # The path where page descriptors can be found, relative to the root folder
 crafter.engine.site.default.descriptors.pages.path=/site/website
 # The path where static assets can be found, relative to the root folder

--- a/engine/src/main/resources/crafter/engine/services/main-services-context.xml
+++ b/engine/src/main/resources/crafter/engine/services/main-services-context.xml
@@ -303,6 +303,10 @@
 		<constructor-arg name="dateConverter" ref="crafter.stringToUtcDateConverter"/>
 	</bean>
 
+	<bean id="crafter.includeByUrlItemPredicate" class="org.craftercms.engine.util.predicates.IncludeByUrlPredicate">
+		<constructor-arg name="includeRegexes" value="${crafter.engine.site.default.descriptors.allowed.paths}"/>
+	</bean>
+
 	<bean id="crafter.excludeLevelDescriptorItemFilter" class="org.craftercms.engine.service.filter.ExcludeByNameItemFilter">
 		<constructor-arg name="excludeRegex"
 				 value="${crafter.core.merger.strategy.inheritLevels.levelDescriptor.name}"/>
@@ -320,10 +324,15 @@
 		<constructor-arg name="predicate" ref="crafter.expiredDtItemPredicate"/>
 	</bean>
 
+	<bean id="crafter.includeByUrlItemFilter" class="org.craftercms.engine.util.predicates.PredicateBasedFilter">
+		<constructor-arg name="predicate" ref="crafter.includeByUrlItemPredicate"/>
+	</bean>
+
 	<util:list id="crafter.defaultItemPredicates">
 		<ref bean="crafter.disabledItemPredicate"/>
 		<ref bean="crafter.expiredItemPredicate"/>
 		<ref bean="crafter.expiredDtItemPredicate"/>
+		<ref bean="crafter.includeByUrlItemPredicate"/>
 	</util:list>
 
 	<util:list id="crafter.defaultItemFilters">
@@ -331,6 +340,7 @@
 		<ref bean="crafter.excludeDisabledItemFilter"/>
 		<ref bean="crafter.excludeExpiredItemFilter"/>
 		<ref bean="crafter.excludeExpiredDtItemFilter"/>
+		<ref bean="crafter.includeByUrlItemFilter"/>
 	</util:list>
 
 	<bean id="crafter.siteItemService" class="org.craftercms.engine.service.impl.SiteItemServiceImpl">


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms-e/issues/1148
SiteItemService return SiteItem only when matching allowed regexes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable URL-based inclusion rules for site items.
  - Site item retrieval now supports allowed URL patterns, including the default site path.
  - Preview mode applies URL inclusion rules by default.
  - Items are included only when their URLs fully match a configured pattern.
  - Added support for checking whether a site item exists at a specified path, improving configuration and content availability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->