### PR TITLE
Add validation to reject null repositoryType

### DIFF
--- a/studio/src/main/java/org/craftercms/studio/model/rest/UnlockRepositoryRequest.java
+++ b/studio/src/main/java/org/craftercms/studio/model/rest/UnlockRepositoryRequest.java
@@ -19,10 +19,13 @@ package org.craftercms.studio.model.rest;
 import org.craftercms.commons.validation.annotations.param.ValidSiteId;
 import org.craftercms.studio.api.v1.constant.GitRepositories;
 
+import jakarta.validation.constraints.NotNull;
+
 public class UnlockRepositoryRequest {
 
 	@ValidSiteId
 	private String siteId;
+	@NotNull
 	private GitRepositories repositoryType;
 
 	public String getSiteId() {


### PR DESCRIPTION
Add validation to reject null repositoryType
https://github.com/craftersoftware/craftercms-e/issues/1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure the repository type is provided when unlocking a repository.
  * Requests with a missing repository type are now rejected with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->