### PR TITLE
Extend pattern to cover plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
                 versions: [ ">=5.0.0" ]
             -   dependency-name: "org.apache.groovy:groovy-sql"
                 versions: [ ">=5.0.0" ]
-            -   dependency-name: "org.springframework.boot:*"
+            -   dependency-name: "*org.springframework.boot*"
                 versions: [ ">=4.0.0" ]
             -   dependency-name: "org.springframework:*"
                 versions: [ ">=7.0.0" ]


### PR DESCRIPTION
Extend pattern to cover plugins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update rules to correctly recognize all supported Spring Boot dependency names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->