### PR TITLE
Update links to readmes in js-sdk packages #8034

### DIFF
--- a/js-sdk/packages/README.md
+++ b/js-sdk/packages/README.md
@@ -2,10 +2,10 @@
 
 Please go into the distinct packages to see docs.
 
-- [classes](./classes)
-- [content](./content)
-- [ice](./ice)
-- [models](./models)
-- [redux](./redux)
-- [search](./search)
-- [utils](./utils)
+- [classes](https://github.com/craftersoftware/craftercms/tree/support/4.x/js-sdk/packages/classes)
+- [content](https://github.com/craftersoftware/craftercms/tree/support/4.x/js-sdk/packages/content)
+- [ice](https://github.com/craftersoftware/craftercms/tree/support/4.x/js-sdk/packages/ice)
+- [models](https://github.com/craftersoftware/craftercms/tree/support/4.x/js-sdk/packages/models)
+- [redux](https://github.com/craftersoftware/craftercms/tree/support/4.x/js-sdk/packages/redux)
+- [search](https://github.com/craftersoftware/craftercms/tree/support/4.x/js-sdk/packages/search)
+- [utils](https://github.com/craftersoftware/craftercms/tree/support/4.x/js-sdk/packages/utils)

--- a/js-sdk/packages/content/README.md
+++ b/js-sdk/packages/content/README.md
@@ -82,7 +82,7 @@ directly importing as a script in the browser, these functions will be under the
 named `craftercms.content` (i.e. `window.craftercms.content`).
 
 ### parseDescriptor
-Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts) or a GraphQL response into a [Content Instance](../models/src/ContentInstance.ts). It could also be a collection of any of these types.
+Parse a [Descriptor](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/descriptor.ts), [Item](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/item.ts) or a GraphQL response into a [Content Instance](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/ContentInstance.ts). It could also be a collection of any of these types.
 
 `parseDescriptor(response: Descriptor | Item | GraphQLResponse | Descriptor[] | Item[] | GraphQLResponse)`
 
@@ -92,7 +92,7 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
 
 #### Returns
 
-[ContentInstance](../models/src/ContentInstance.ts)
+[ContentInstance](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/ContentInstance.ts)
 
 #### Examples
 
@@ -153,11 +153,11 @@ Get an Item from the content store.
 | Parameters    |                |
 | ------------- |:--------------:|
 | path          | The item’s path in the content store |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
+| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
-[Item](../models/README.md#Item) - from the content store
+[Item](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#Item) - from the content store
 
 #### Examples
 
@@ -194,11 +194,11 @@ Get the descriptor data of an Item in the content store.
 | Parameters    |                |
 | ------------- |:--------------:|
 | path          | The item’s path in the content store |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
+| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
-[Descriptor](../models/README.md#Descriptor) - from the content store
+[Descriptor](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#Descriptor) - from the content store
 
 #### Examples
 
@@ -232,11 +232,11 @@ Get the list of Items directly under a folder in the content store.
 | Parameters    |                |
 | ------------- |:--------------:|
 | path          | The folder’s path |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
+| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
-[Item](../models/README.md#Item)[] - List of Items from the content store
+[Item](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#Item)[] - List of Items from the content store
 
 #### Examples
 
@@ -265,11 +265,11 @@ Get the complete Item hierarchy under the specified folder in the content store.
 | ------------- |:--------------:|
 | path          | The folder’s path |
 | depth         | Amount of levels to include. Optional. Default is `1` |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
+| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
-[Item](../models/README.md#Item) - from the content store
+[Item](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#Item) - from the content store
 
 #### Examples
 
@@ -301,11 +301,11 @@ Returns the navigation tree with the specified depth for the specified store URL
 | path           | The folder’s path |
 | depth          | Amount of levels to include. Optional. Default is `1` |
 | currentPageUrl | The URL of the current page. Optional. Default is `''` |
-| config         | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
+| config         | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
-[NavigationItem](../models/README.md#NavigationItem) - from the content store
+[NavigationItem](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#NavigationItem) - from the content store
 
 #### Examples
 
@@ -334,11 +334,11 @@ Returns the navigation items that form the breadcrumb for the specified store UR
 | -------------- |:--------------:|
 | path            | The folder’s path |
 | root           | the root URL, basically the starting point of the breadcrumb. Optional. Default is `''` |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
+| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 
-[NavigationItem](../models/README.md#NavigationItem)[] - List of NavigationItem from the content store
+[NavigationItem](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#NavigationItem)[] - List of NavigationItem from the content store
 
 #### Examples
 
@@ -367,7 +367,7 @@ Transforms a URL, based on the current site’s configuration.
 | --------------- |:--------------:|
 | transformerName | Name of the transformer to apply |
 | path             | URL that will be transformed |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
+| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 

--- a/js-sdk/packages/content/README.md
+++ b/js-sdk/packages/content/README.md
@@ -20,9 +20,9 @@ All of Crafter CMS packages can be used either via npm or in plain html/javascri
 - Download the bundle and import them in your page.
 - The bundle declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
 - The `content` package depends on `rxjs`, `@craftercms/utils`, `@craftercms/classes`; make sure to import those too before the `content` script.
- 
+
 **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
- 
+
 #### Vanilla html/js example
  ```html
 <div id="myFeature"></div>
@@ -61,14 +61,14 @@ You may pre-configure content services to a certain configuration to then you ma
   import { getItem } from '@craftercms/content';
   import { crafterConf } from '@craftercms/classes';
 
-  // Configure crafter services "globally". Your config will be cached. 
+  // Configure crafter services "globally". Your config will be cached.
   // All content services use the specified configuration on subsequent calls.
   crafterConf.configure({
     baseUrl: 'http://authoring.company.com',
     site: 'editorial'
   });
- 
-  // Second param "config" will use "http://authoring.company.com" as 
+
+  // Second param "config" will use "http://authoring.company.com" as
   // crafter base url and "editorial" as the site to query
   getItem('/site/website/index.xml').subscribe((item: Item) => {
     console.log(item);
@@ -77,7 +77,7 @@ You may pre-configure content services to a certain configuration to then you ma
 
 ## Package Index
 
-The examples below assume usage in the style of using via npm. If you're using the bundles, 
+The examples below assume usage in the style of using via npm. If you're using the bundles,
 directly importing as a script in the browser, these functions will be under the global variable
 named `craftercms.content` (i.e. `window.craftercms.content`).
 
@@ -102,7 +102,7 @@ Parse a [Descriptor](https://github.com/craftersoftware/craftercms/blob/support/
   import { map } from 'rxjs/operators';
   import { ContentInstance } from '@craftercms/models';
   import { getChildren, getItem, parseDescriptor } from '@craftercms/content';
-  
+
   getItem('/site/website/index.xml', { site: 'editorial' }).pipe(
     map(parseDescriptor)
   ).subscribe((content: ContentInstance) => {
@@ -118,7 +118,7 @@ Parse a [Descriptor](https://github.com/craftersoftware/craftercms/blob/support/
 
 ### preParseSearchResults
 Inspects and parses elasticsearch hits and pre-parses objects before they can be sent to parseDescriptor
-@see https://github.com/craftersoftware/craftercms/issues/4057 
+@see https://github.com/craftersoftware/craftercms/issues/4057
 
 ```js
 import { createQuery, search } from '@craftercms/search';
@@ -150,14 +150,14 @@ Get an Item from the content store.
 
 `getItem(path: string, config?: CrafterConfig)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| path          | The item’s path in the content store |
-| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
+| Parameters    |                                                                                                                                                                                 |
+| ------------- |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| path          |                                                                      The item’s path in the content store                                                                       |
+| config        | Crafter configuration. Optional. Default value in [CrafterConfig](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/crafter-config.ts). |
 
 #### Returns
 
-[Item](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#Item) - from the content store
+[Item](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/item.ts) - from the content store
 
 #### Examples
 
@@ -165,8 +165,8 @@ Get an Item from the content store.
 
 ```typescript
   import { Item } from '@craftercms/models';
-  import { getItem } from '@craftercms/content'; 
-  
+  import { getItem } from '@craftercms/content';
+
   getItem('/site/website/index.xml', { site: 'editorial' }).subscribe((item: Item) => {
     console.log(item);
   });
@@ -178,7 +178,7 @@ Get an Item from the content store.
   import { map } from 'rxjs/operators';
   import { ContentInstance } from '@craftercms/models';
   import { getItem, parseDescriptor } from '@craftercms/content';
-  
+
   getItem('/site/website/index.xml', { site: 'editorial' }).pipe(
     map(parseDescriptor)
   ).subscribe((content: ContentInstance) => {
@@ -189,7 +189,7 @@ Get an Item from the content store.
 ### Get Descriptor
 Get the descriptor data of an Item in the content store.
 
-`getDescriptor(path: string, config?: CrafterConfig)` 
+`getDescriptor(path: string, config?: CrafterConfig)`
 
 | Parameters    |                |
 | ------------- |:--------------:|
@@ -214,7 +214,7 @@ Get the descriptor data of an Item in the content store.
     console.log(descriptor);
   });
 
-  // Example 2: 
+  // Example 2:
   // - Omit config (must have configured earlier @see Usage section above)
   // - Parse the response
   getDescriptor('/site/website/index.xml').pipe(
@@ -227,7 +227,7 @@ Get the descriptor data of an Item in the content store.
 ### Get Children
 Get the list of Items directly under a folder in the content store.
 
-`getChildren(path: string, config?: CrafterConfig)` 
+`getChildren(path: string, config?: CrafterConfig)`
 
 | Parameters    |                |
 | ------------- |:--------------:|
@@ -249,7 +249,7 @@ Get the list of Items directly under a folder in the content store.
   getChildren('/site/website', { site: 'editorial' }).subscribe((children) => {
     console.log(children);
   });
-  
+
   // Example 2: Omits the config param (must have been previously configured, see Usage section above)
   getChildren('/site/website').subscribe((children) => {
     console.log(children);
@@ -259,7 +259,7 @@ Get the list of Items directly under a folder in the content store.
 ### Get Tree
 Get the complete Item hierarchy under the specified folder in the content store.
 
-`getTree(path: string, depth: number, config: CrafterConfig)` 
+`getTree(path: string, depth: number, config: CrafterConfig)`
 
 | Parameters    |                |
 | ------------- |:--------------:|
@@ -359,9 +359,9 @@ Returns the navigation items that form the breadcrumb for the specified store UR
 ```
 
 ### Transform
-Transforms a URL, based on the current site’s configuration. 
+Transforms a URL, based on the current site’s configuration.
 
-- `transform(transformerName: string, path: string, config: CrafterConfig)` 
+- `transform(transformerName: string, path: string, config: CrafterConfig)`
 
 | Parameters      |                |
 | --------------- |:--------------:|
@@ -397,7 +397,7 @@ string - URL transformed according to transformer applied.
   import { transform } from '@craftercms/content';
 
   // Assuming that you already set the configuration (as explained above)
-  
+
   // Example 1: Config supplied inline
   transform('renderUrlToStoreUrl', '/technology', { site: 'editorial' }).subscribe((path) => {
     console.log(path); // "/site/website/technology/index.xml"

--- a/js-sdk/packages/ice/README.md
+++ b/js-sdk/packages/ice/README.md
@@ -4,7 +4,7 @@
 
 Contains JavaScript utilities to use Crafter CMS' in-context editing in your apps and sites
 
-**Note**: All methods of this package work with [Content Instance](../models/src/ContentInstance.ts) as data structure they understand (the model param). Use in conjunction with `parseDescriptor` and `preParseSearchResults` from `@craftercms/content` to obtain such data structure.
+**Note**: All methods of this package work with [Content Instance](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/ContentInstance.ts) as data structure they understand (the model param). Use in conjunction with `parseDescriptor` and `preParseSearchResults` from `@craftercms/content` to obtain such data structure.
 
 ## Usage
 

--- a/js-sdk/packages/search/README.md
+++ b/js-sdk/packages/search/README.md
@@ -20,9 +20,9 @@ All of Crafter CMS packages can be used either via npm or in plain html/javascri
 - Download the bundle and import them in your page.
 - The bundles declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
 - The `search` package depends on `rxjs`, `@craftercms/utils`, `@craftercms/classes`; make sure to import those too before the `search` script.
- 
+
 **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
- 
+
 #### Vanilla html/js example
 
  ```html
@@ -64,19 +64,19 @@ All of Crafter CMS packages can be used either via npm or in plain html/javascri
 
 ## Package Index
 
-The examples below assume usage in the style of using via npm. If you're using the bundles, 
+The examples below assume usage in the style of using via npm. If you're using the bundles,
 directly importing as a script in the browser, these functions will be under the global variable
 named `craftercms.search` (i.e. `window.craftercms.search`).
 
 ### search
 Returns the result for a given query.
 
-`search(query: Query)` 
+`search(query: Query)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| query         | The query object |
-| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
+| Parameters    |                                                                                                                                                                                 |
+| ------------- |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| query         |                                                                                The query object                                                                                 |
+| config        | Crafter configuration. Optional. Default value in [CrafterConfig](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/src/crafter-config.ts). |
 
 #### Returns
 
@@ -92,7 +92,7 @@ Map model
   import { map } from 'rxjs/operators';
   import { parseDescriptor, preParseSearchResults } from '@craftercms/content';
 
-  // First, set the Crafter configuration to cache your config. 
+  // First, set the Crafter configuration to cache your config.
   // All subsequent calls to `getConfig` will use that configuration.
   crafterConf.configure({
     baseUrl: 'http://localhost:8080',
@@ -117,11 +117,11 @@ Map model
     // { baseUrl: 'http://localhost:8080', site: 'wordify' }
   ).pipe(
     map(({ hits, ...rest }) => {
-      return { 
-        ...rest, 
+      return {
+        ...rest,
         hits: hits.map(({ _source }) => parseDescriptor(
           preParseSearchResults(_source)
-        )) 
+        ))
       };
     })
   ).subscribe((results) => {

--- a/js-sdk/packages/search/README.md
+++ b/js-sdk/packages/search/README.md
@@ -76,7 +76,7 @@ Returns the result for a given query.
 | Parameters    |                |
 | ------------- |:--------------:|
 | query         | The query object |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
+| config        | Crafter configuration. Optional. Default value in [here](https://github.com/craftersoftware/craftercms/blob/support/4.x/js-sdk/packages/models/README.md#CrafterConfig). |
 
 #### Returns
 


### PR DESCRIPTION
### Ticket reference or the full description of what's in the PR
Update links to readmes in js-sdk packages  https://github.com/craftersoftware/craftercms/issues/8054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated package documentation links to point to the Crafter CMS GitHub repository’s `support/4.x` branch.
  * Updated content API references, including parsing, retrieval, navigation, and transformation documentation.
  * Updated links for Content Instance and search configuration documentation.
  * Improved formatting and expanded search API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->