### PR TITLE
Add cleanup support to UM for 3.x Index group_ibfk_1

### DIFF
--- a/studio/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.17-to-5.0.0.18.sql
+++ b/studio/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.17-to-5.0.0.18.sql
@@ -18,7 +18,9 @@ ALTER TABLE `audit` DROP COLUMN IF EXISTS `organization_id` ;
 
 ALTER TABLE `group`
 	DROP FOREIGN KEY IF EXISTS `group_ix_org_id`,
+	DROP FOREIGN KEY IF EXISTS `group_ibfk_1`,
 	DROP INDEX IF EXISTS `group_ix_org_id`,
+	DROP INDEX IF EXISTS `group_ibfk_1`,
 	DROP COLUMN IF EXISTS `org_id` ;
 DROP TABLE IF EXISTS `organization_user` ;
 DROP TABLE IF EXISTS `organization` ;


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/8744
Add cleanup support to UM for 3.x Index group_ibfk_1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database upgrade handling by ensuring obsolete organization-related group constraints and indexes are removed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->